### PR TITLE
feat(wf-registration): register parent and child wf in order

### DIFF
--- a/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
+++ b/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
@@ -10,7 +10,6 @@ import io.littlehorse.quarkus.deployment.item.LHTaskMethodBuildItem;
 import io.littlehorse.quarkus.deployment.item.LHUserTaskFormBuildItem;
 import io.littlehorse.quarkus.deployment.item.LHWorkflowBuildItem;
 import io.littlehorse.quarkus.runtime.LHRecorder;
-import io.littlehorse.quarkus.runtime.recordable.LHRecordableDependenciesGraph;
 import io.littlehorse.quarkus.runtime.recordable.LHStructDefRecordable;
 import io.littlehorse.quarkus.runtime.recordable.LHWorkflowRecordable;
 import io.littlehorse.quarkus.task.LHUserTaskForm;
@@ -141,9 +140,7 @@ class LHServiceProcessor {
         List<LHStructDefRecordable> structDefRecordables = structDefBuildItems.stream()
                 .map(LHStructDefBuildItem::toRecordable)
                 .toList();
-        LHRecordableDependenciesGraph<LHStructDefRecordable> structDefRecordableGraph =
-                new LHRecordableDependenciesGraph<>(structDefRecordables);
-        structDefRecordableGraph.toOrderedList().forEach(recorder::registerLHStructDef);
+        recorder.registerLHStructDefs(structDefRecordables);
 
         taskMethodBuildItems.stream()
                 .map(LHTaskMethodBuildItem::toRecordable)
@@ -156,9 +153,7 @@ class LHServiceProcessor {
         List<LHWorkflowRecordable> workflowRecordables = workflowBuildItems.stream()
                 .map(LHWorkflowBuildItem::toRecordable)
                 .toList();
-        LHRecordableDependenciesGraph<LHWorkflowRecordable> workflowRecordableGraph =
-                new LHRecordableDependenciesGraph<>(workflowRecordables);
-        workflowRecordableGraph.toOrderedList().forEach(recorder::registerLHWorkflow);
+        recorder.registerLHWorkflows(workflowRecordables);
 
         return new ServiceStartBuildItem("LittleHorse");
     }

--- a/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/LHRecorder.java
+++ b/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/LHRecorder.java
@@ -3,26 +3,20 @@ package io.littlehorse.quarkus.runtime;
 import io.littlehorse.quarkus.config.ConfigEvaluator;
 import io.littlehorse.quarkus.config.LHRuntimeConfig;
 import io.littlehorse.quarkus.runtime.health.LHTaskStatus;
-import io.littlehorse.quarkus.runtime.recordable.LHExponentialBackoffRetryRecordable;
+import io.littlehorse.quarkus.runtime.recordable.LHRecordableDependenciesGraph;
 import io.littlehorse.quarkus.runtime.recordable.LHStructDefRecordable;
 import io.littlehorse.quarkus.runtime.recordable.LHTaskMethodRecordable;
 import io.littlehorse.quarkus.runtime.recordable.LHUserTaskFormRecordable;
 import io.littlehorse.quarkus.runtime.recordable.LHWorkflowRecordable;
 import io.littlehorse.quarkus.task.LHUserTaskForm;
 import io.littlehorse.quarkus.workflow.LHWorkflow;
-import io.littlehorse.quarkus.workflow.LHWorkflowDefinition;
 import io.littlehorse.sdk.common.config.LHConfig;
-import io.littlehorse.sdk.common.proto.AllowedUpdateType;
-import io.littlehorse.sdk.common.proto.ExponentialBackoffRetryPolicy;
 import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
 import io.littlehorse.sdk.common.proto.PutStructDefRequest;
 import io.littlehorse.sdk.common.proto.PutUserTaskDefRequest;
 import io.littlehorse.sdk.common.proto.StructDefCompatibilityType;
-import io.littlehorse.sdk.common.proto.ThreadRetentionPolicy;
-import io.littlehorse.sdk.common.proto.WorkflowRetentionPolicy;
 import io.littlehorse.sdk.usertask.UserTaskSchema;
 import io.littlehorse.sdk.wfsdk.Workflow;
-import io.littlehorse.sdk.wfsdk.WorkflowThread;
 import io.littlehorse.sdk.wfsdk.internal.structdefutil.LHStructDefType;
 import io.littlehorse.sdk.worker.LHStructDef;
 import io.littlehorse.sdk.worker.LHTaskMethod;
@@ -36,8 +30,7 @@ import jakarta.enterprise.inject.spi.CDI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Optional;
 
 @Recorder
@@ -86,6 +79,12 @@ public class LHRecorder {
         }
     }
 
+    public void registerLHWorkflows(List<LHWorkflowRecordable> workflowRecordables) {
+        LHRecordableDependenciesGraph<LHWorkflowRecordable> workflowRecordableGraph =
+                new LHRecordableDependenciesGraph<>(workflowRecordables);
+        workflowRecordableGraph.toOrderedList().forEach(this::registerLHWorkflow);
+    }
+
     public void registerLHWorkflow(LHWorkflowRecordable recordable) {
         if (!doesBeanExist(recordable.getBeanClass())) return;
 
@@ -100,86 +99,7 @@ public class LHRecorder {
 
         if (!registerWorkflow) return;
 
-        Workflow workflow = Workflow.newWorkflow(expandedName, thread -> {
-            if (recordable.getBeanMethodName() == null) {
-                LHWorkflowDefinition workflowDefinitionBean =
-                        (LHWorkflowDefinition) getBean(recordable.getBeanClass());
-                workflowDefinitionBean.define(thread);
-                return;
-            }
-
-            try {
-                Method method = recordable
-                        .getBeanClass()
-                        .getMethod(recordable.getBeanMethodName(), WorkflowThread.class);
-                method.invoke(getBean(recordable.getBeanClass()), thread);
-            } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
-        });
-
-        String parent = recordable.getParent();
-        if (parent != null) {
-            workflow.setParent(configEvaluator.expand(parent).asString());
-        }
-
-        String defaultTaskTimeout = recordable.getDefaultTaskTimeout();
-        if (defaultTaskTimeout != null) {
-            workflow.setDefaultTaskTimeout(
-                    configEvaluator.expand(defaultTaskTimeout).asInt());
-        }
-
-        String defaultTaskRetries = recordable.getDefaultTaskRetries();
-        if (defaultTaskRetries != null) {
-            workflow.setDefaultTaskRetries(
-                    configEvaluator.expand(defaultTaskRetries).asInt());
-        }
-
-        String updateType = recordable.getUpdateType();
-        if (updateType != null) {
-            workflow.withUpdateType(AllowedUpdateType.valueOf(
-                    configEvaluator.expand(updateType).asString().toUpperCase()));
-        }
-
-        String retention = recordable.getRetention();
-        if (retention != null) {
-            workflow.withRetentionPolicy(WorkflowRetentionPolicy.newBuilder()
-                    .setSecondsAfterWfTermination(
-                            configEvaluator.expand(retention).asLong())
-                    .build());
-        }
-
-        String defaultThreadRetention = recordable.getDefaultThreadRetention();
-        if (defaultThreadRetention != null) {
-            workflow.withDefaultThreadRetentionPolicy(ThreadRetentionPolicy.newBuilder()
-                    .setSecondsAfterThreadTermination(
-                            configEvaluator.expand(defaultThreadRetention).asLong())
-                    .build());
-        }
-
-        LHExponentialBackoffRetryRecordable retryRecordable = recordable.getRetryRecordable();
-        if (retryRecordable != null) {
-            ExponentialBackoffRetryPolicy.Builder backoffRetryBuilder =
-                    ExponentialBackoffRetryPolicy.newBuilder();
-
-            if (retryRecordable.getBaseIntervalMs() != null) {
-                backoffRetryBuilder.setBaseIntervalMs(configEvaluator
-                        .expand(retryRecordable.getBaseIntervalMs())
-                        .asInt());
-            }
-
-            if (retryRecordable.getMultiplier() != null) {
-                backoffRetryBuilder.setMultiplier(
-                        configEvaluator.expand(retryRecordable.getMultiplier()).asFloat());
-            }
-
-            if (retryRecordable.getMaxDelayMs() != null) {
-                backoffRetryBuilder.setMaxDelayMs(
-                        configEvaluator.expand(retryRecordable.getMaxDelayMs()).asLong());
-            }
-
-            workflow.setDefaultTaskExponentialBackoffPolicy(backoffRetryBuilder.build());
-        }
+        Workflow workflow = recordable.toWorkflow();
 
         logEvent("Registering", LHWorkflow.class, expandedName);
 
@@ -206,6 +126,12 @@ public class LHRecorder {
 
         logEvent("Registering", LHUserTaskForm.class, expandedName);
         getBlockingStub().putUserTaskDef(request);
+    }
+
+    public void registerLHStructDefs(List<LHStructDefRecordable> structDefRecordables) {
+        LHRecordableDependenciesGraph<LHStructDefRecordable> structDefRecordableGraph =
+                new LHRecordableDependenciesGraph<>(structDefRecordables);
+        structDefRecordableGraph.toOrderedList().forEach(this::registerLHStructDef);
     }
 
     public void registerLHStructDef(LHStructDefRecordable recordable) {

--- a/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/recordable/LHRecordable.java
+++ b/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/recordable/LHRecordable.java
@@ -1,6 +1,6 @@
 package io.littlehorse.quarkus.runtime.recordable;
 
-import java.util.List;
+import java.util.Set;
 
 public abstract class LHRecordable {
 
@@ -20,7 +20,7 @@ public abstract class LHRecordable {
         return name;
     }
 
-    public List<String> dependencies() {
-        return List.of();
+    public Set<String> dependencies() {
+        return Set.of();
     }
 }

--- a/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/recordable/LHStructDefRecordable.java
+++ b/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/recordable/LHStructDefRecordable.java
@@ -4,7 +4,8 @@ import io.littlehorse.sdk.common.proto.StructDefId;
 import io.littlehorse.sdk.wfsdk.internal.structdefutil.LHStructDefType;
 import io.quarkus.runtime.annotations.RecordableConstructor;
 
-import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class LHStructDefRecordable extends LHRecordable {
 
@@ -21,12 +22,12 @@ public class LHStructDefRecordable extends LHRecordable {
     }
 
     @Override
-    public List<String> dependencies() {
+    public Set<String> dependencies() {
         LHStructDefType structDefType = new LHStructDefType(getBeanClass());
         return structDefType.getDependencyClasses().stream()
                 .map(LHStructDefType::getStructDefId)
                 .map(StructDefId::getName)
                 .filter(name -> !name.equals(getName()))
-                .toList();
+                .collect(Collectors.toSet());
     }
 }

--- a/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/recordable/LHWorkflowRecordable.java
+++ b/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/recordable/LHWorkflowRecordable.java
@@ -1,8 +1,21 @@
 package io.littlehorse.quarkus.runtime.recordable;
 
+import io.littlehorse.quarkus.config.ConfigEvaluator;
+import io.littlehorse.quarkus.workflow.LHWorkflowDefinition;
+import io.littlehorse.sdk.common.proto.AllowedUpdateType;
+import io.littlehorse.sdk.common.proto.ExponentialBackoffRetryPolicy;
+import io.littlehorse.sdk.common.proto.ThreadRetentionPolicy;
+import io.littlehorse.sdk.common.proto.WorkflowRetentionPolicy;
+import io.littlehorse.sdk.wfsdk.Workflow;
+import io.littlehorse.sdk.wfsdk.WorkflowThread;
 import io.quarkus.runtime.annotations.RecordableConstructor;
 
-import java.util.List;
+import jakarta.enterprise.inject.spi.CDI;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
 
 public class LHWorkflowRecordable extends LHRecordable {
 
@@ -71,10 +84,100 @@ public class LHWorkflowRecordable extends LHRecordable {
     }
 
     @Override
-    public List<String> dependencies() {
-        if (getParent() == null) {
-            return List.of();
+    public Set<String> dependencies() {
+        Workflow workflow = toWorkflow();
+        Set<String> deps = new HashSet<>();
+        if (getParent() != null) {
+            deps.add(getParent());
         }
-        return List.of(getParent());
+        deps.addAll(workflow.getRequiredChildWfSpecNames());
+        return deps;
+    }
+
+    public Workflow toWorkflow() {
+        ConfigEvaluator configEvaluator =
+                CDI.current().select(ConfigEvaluator.class).get();
+        String expandedName = configEvaluator.expand(getName()).asString();
+
+        Workflow workflow = Workflow.newWorkflow(expandedName, thread -> {
+            if (getBeanMethodName() == null) {
+                LHWorkflowDefinition workflowDefinitionBean = (LHWorkflowDefinition)
+                        CDI.current().select(getBeanClass()).get();
+                workflowDefinitionBean.define(thread);
+                return;
+            }
+
+            try {
+                Method method = getBeanClass().getMethod(getBeanMethodName(), WorkflowThread.class);
+                method.invoke(CDI.current().select(getBeanClass()).get(), thread);
+            } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        String parent = getParent();
+        if (parent != null) {
+            workflow.setParent(configEvaluator.expand(parent).asString());
+        }
+
+        String defaultTaskTimeout = getDefaultTaskTimeout();
+        if (defaultTaskTimeout != null) {
+            workflow.setDefaultTaskTimeout(
+                    configEvaluator.expand(defaultTaskTimeout).asInt());
+        }
+
+        String defaultTaskRetries = getDefaultTaskRetries();
+        if (defaultTaskRetries != null) {
+            workflow.setDefaultTaskRetries(
+                    configEvaluator.expand(defaultTaskRetries).asInt());
+        }
+
+        String updateType = getUpdateType();
+        if (updateType != null) {
+            workflow.withUpdateType(AllowedUpdateType.valueOf(
+                    configEvaluator.expand(updateType).asString().toUpperCase()));
+        }
+
+        String retention = getRetention();
+        if (retention != null) {
+            workflow.withRetentionPolicy(WorkflowRetentionPolicy.newBuilder()
+                    .setSecondsAfterWfTermination(
+                            configEvaluator.expand(retention).asLong())
+                    .build());
+        }
+
+        String defaultThreadRetention = getDefaultThreadRetention();
+        if (defaultThreadRetention != null) {
+            workflow.withDefaultThreadRetentionPolicy(ThreadRetentionPolicy.newBuilder()
+                    .setSecondsAfterThreadTermination(
+                            configEvaluator.expand(defaultThreadRetention).asLong())
+                    .build());
+        }
+
+        LHExponentialBackoffRetryRecordable retryRecordable = getRetryRecordable();
+        if (retryRecordable != null) {
+            ExponentialBackoffRetryPolicy.Builder backoffRetryBuilder =
+                    ExponentialBackoffRetryPolicy.newBuilder();
+
+            if (retryRecordable.getBaseIntervalMs() != null) {
+                backoffRetryBuilder.setBaseIntervalMs(configEvaluator
+                        .expand(retryRecordable.getBaseIntervalMs())
+                        .asInt());
+            }
+
+            if (retryRecordable.getMultiplier() != null) {
+                backoffRetryBuilder.setMultiplier(
+                        configEvaluator.expand(retryRecordable.getMultiplier()).asFloat());
+            }
+
+            if (retryRecordable.getMaxDelayMs() != null) {
+                backoffRetryBuilder.setMaxDelayMs(
+                        configEvaluator.expand(retryRecordable.getMaxDelayMs()).asLong());
+            }
+
+            workflow.setDefaultTaskExponentialBackoffPolicy(backoffRetryBuilder.build());
+        }
+
+        return workflow;
     }
 }

--- a/extensions/littlehorse-quarkus/runtime/src/test/java/io/littlehorse/quarkus/runtime/recordable/LHRecordableDependenciesGraphTest.java
+++ b/extensions/littlehorse-quarkus/runtime/src/test/java/io/littlehorse/quarkus/runtime/recordable/LHRecordableDependenciesGraphTest.java
@@ -4,69 +4,86 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 class LHRecordableDependenciesGraphTest {
 
-    private static LHWorkflowRecordable newRecordable(String name, String parent) {
-        return new LHWorkflowRecordable(
-                null, name, null, parent, null, null, null, null, null, null);
+    private static class DummyRecordable extends LHRecordable {
+
+        private final Set<String> deps;
+
+        DummyRecordable(String name, String... dependencies) {
+            super(null, name);
+            this.deps = new LinkedHashSet<>(Arrays.asList(dependencies));
+        }
+
+        @Override
+        public Set<String> dependencies() {
+            return deps;
+        }
+    }
+
+    private static DummyRecordable newRecordable(String name, String... dependencies) {
+        return new DummyRecordable(name, dependencies);
     }
 
     @Test
     void shouldSortChildAndParent() {
-        LHWorkflowRecordable child = newRecordable("my-child", "my-parent");
-        LHWorkflowRecordable parent = newRecordable("my-parent", null);
+        DummyRecordable child = newRecordable("my-child", "my-parent");
+        DummyRecordable parent = newRecordable("my-parent");
 
-        LHRecordableDependenciesGraph<LHWorkflowRecordable> graph =
+        LHRecordableDependenciesGraph<DummyRecordable> graph =
                 new LHRecordableDependenciesGraph<>(List.of(child, parent));
         assertThat(graph.toOrderedList()).containsExactly(parent, child);
     }
 
     @Test
     void shouldSortMultipleParent() {
-        LHWorkflowRecordable child = newRecordable("my-child", "my-parent1");
-        LHWorkflowRecordable parent1 = newRecordable("my-parent1", "my-parent2");
-        LHWorkflowRecordable parent2 = newRecordable("my-parent2", null);
+        DummyRecordable child = newRecordable("my-child", "my-parent1");
+        DummyRecordable parent1 = newRecordable("my-parent1", "my-parent2");
+        DummyRecordable parent2 = newRecordable("my-parent2");
 
-        LHRecordableDependenciesGraph<LHWorkflowRecordable> graph =
+        LHRecordableDependenciesGraph<DummyRecordable> graph =
                 new LHRecordableDependenciesGraph<>(List.of(child, parent1, parent2));
         assertThat(graph.toOrderedList()).containsExactly(parent2, parent1, child);
     }
 
     @Test
     void shouldSortNotParent() {
-        LHWorkflowRecordable other = newRecordable("other", null);
-        LHWorkflowRecordable child = newRecordable("my-child", "my-parent1");
-        LHWorkflowRecordable parent1 = newRecordable("my-parent1", "my-parent2");
-        LHWorkflowRecordable parent2 = newRecordable("my-parent2", null);
+        DummyRecordable other = newRecordable("other");
+        DummyRecordable child = newRecordable("my-child", "my-parent1");
+        DummyRecordable parent1 = newRecordable("my-parent1", "my-parent2");
+        DummyRecordable parent2 = newRecordable("my-parent2");
 
-        LHRecordableDependenciesGraph<LHWorkflowRecordable> graph =
+        LHRecordableDependenciesGraph<DummyRecordable> graph =
                 new LHRecordableDependenciesGraph<>(List.of(child, parent1, parent2, other));
         assertThat(graph.toOrderedList()).containsExactly(parent2, other, parent1, child);
     }
 
     @Test
     void shouldSortWithMultipleChild() {
-        LHWorkflowRecordable wf1 = newRecordable("wf1", "wf2");
-        LHWorkflowRecordable wf2 = newRecordable("wf2", "wf3");
-        LHWorkflowRecordable wf3 = newRecordable("wf3", null);
-        LHWorkflowRecordable wf4 = newRecordable("wf4", null);
-        LHWorkflowRecordable wf5 = newRecordable("wf5", "wf3");
+        DummyRecordable wf1 = newRecordable("wf1", "wf2");
+        DummyRecordable wf2 = newRecordable("wf2", "wf3");
+        DummyRecordable wf3 = newRecordable("wf3");
+        DummyRecordable wf4 = newRecordable("wf4");
+        DummyRecordable wf5 = newRecordable("wf5", "wf3");
 
-        LHRecordableDependenciesGraph<LHWorkflowRecordable> graph =
+        LHRecordableDependenciesGraph<DummyRecordable> graph =
                 new LHRecordableDependenciesGraph<>(List.of(wf4, wf5, wf3, wf1, wf2));
         assertThat(graph.toOrderedList()).containsExactly(wf4, wf3, wf5, wf2, wf1);
     }
 
     @Test
     void shouldSortMissingParent() {
-        LHWorkflowRecordable wf1 = newRecordable("wf1", "wf2");
-        LHWorkflowRecordable wf2 = newRecordable("wf2", "wf3");
-        LHWorkflowRecordable wf4 = newRecordable("wf4", null);
-        LHWorkflowRecordable wf5 = newRecordable("wf5", "wf3");
+        DummyRecordable wf1 = newRecordable("wf1", "wf2");
+        DummyRecordable wf2 = newRecordable("wf2", "wf3");
+        DummyRecordable wf4 = newRecordable("wf4");
+        DummyRecordable wf5 = newRecordable("wf5", "wf3");
 
-        LHRecordableDependenciesGraph<LHWorkflowRecordable> graph =
+        LHRecordableDependenciesGraph<DummyRecordable> graph =
                 new LHRecordableDependenciesGraph<>(List.of(wf4, wf5, wf1, wf2));
         assertThat(graph.toOrderedList()).containsExactly(wf4, wf5, wf2, wf1);
     }

--- a/integration-tests/src/integrationTest/java/io/littlehorse/test/ChildWorkflowRegistrationTest.java
+++ b/integration-tests/src/integrationTest/java/io/littlehorse/test/ChildWorkflowRegistrationTest.java
@@ -1,0 +1,48 @@
+package io.littlehorse.test;
+
+import static io.littlehorse.workflows.NestedChildWorkflows.CHILD_WF;
+import static io.littlehorse.workflows.NestedChildWorkflows.GRANDPARENT_WF;
+import static io.littlehorse.workflows.NestedChildWorkflows.PARENT_WF;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.with;
+
+import io.littlehorse.common.ContainersTestResource;
+import io.littlehorse.common.InjectLittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.WfSpec;
+import io.littlehorse.sdk.common.proto.WfSpecId;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+@QuarkusIntegrationTest
+@QuarkusTestResource(ContainersTestResource.class)
+class ChildWorkflowRegistrationTest {
+
+    @InjectLittleHorseBlockingStub
+    LittleHorseBlockingStub blockingStub;
+
+    @Test
+    void shouldRegisterNestedChildWorkflows() {
+        with().pollInterval(Duration.ofSeconds(1))
+                .ignoreExceptions()
+                .await()
+                .atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> {
+                    WfSpec grandparent = blockingStub.getWfSpec(
+                            WfSpecId.newBuilder().setName(GRANDPARENT_WF).build());
+                    WfSpec parent = blockingStub.getWfSpec(
+                            WfSpecId.newBuilder().setName(PARENT_WF).build());
+                    WfSpec child = blockingStub.getWfSpec(
+                            WfSpecId.newBuilder().setName(CHILD_WF).build());
+
+                    assertThat(grandparent.getId().getName()).isEqualTo(GRANDPARENT_WF);
+                    assertThat(parent.getId().getName()).isEqualTo(PARENT_WF);
+                    assertThat(child.getId().getName()).isEqualTo(CHILD_WF);
+                });
+    }
+}

--- a/integration-tests/src/integrationTest/java/io/littlehorse/test/RESTfulGatewayTenantTest.java
+++ b/integration-tests/src/integrationTest/java/io/littlehorse/test/RESTfulGatewayTenantTest.java
@@ -21,6 +21,7 @@ import net.datafaker.Faker;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.UUID;
 
 @QuarkusIntegrationTest
 @QuarkusTestResource(ContainersTestResource.class)
@@ -34,8 +35,8 @@ class RESTfulGatewayTenantTest {
     @Test
     void shouldGetWfSpecFromTenant() {
         // create tenant
-        String tenant = faker.internet().domainWord();
-        String wfName = faker.internet().domainWord();
+        String tenant = faker.internet().domainWord() + UUID.randomUUID();
+        String wfName = faker.internet().domainWord() + UUID.randomUUID();
         registerTenantAndWf(tenant, wfName);
 
         // test

--- a/integration-tests/src/integrationTest/java/io/littlehorse/test/RESTfulGatewayWfSpecTest.java
+++ b/integration-tests/src/integrationTest/java/io/littlehorse/test/RESTfulGatewayWfSpecTest.java
@@ -69,19 +69,22 @@ class RESTfulGatewayWfSpecTest {
                 .get("/gateway/tenants/{tenant}/wf-specs")
                 .then()
                 .statusCode(200)
-                .body("results", hasSize(4))
+                .body("results", hasSize(7))
                 .body("bookmark", is(nullValue()))
                 .body("results[0].name", is("example-type-adapter"))
                 .body("results[1].name", is("greetings"))
                 .body("results[2].name", is("json"))
-                .body("results[3].name", is("workflow-in-a-bean"))
+                .body("results[3].name", is("nested-child-wf"))
+                .body("results[4].name", is("nested-grandparent-wf"))
+                .body("results[5].name", is("nested-parent-wf"))
+                .body("results[6].name", is("workflow-in-a-bean"))
                 .log()
                 .all();
     }
 
     @Test
     void shouldSearchWfSpecWithBookmark() {
-        int limit = 2;
+        int limit = 4;
         Response getFirstObject = given().pathParam("tenant", "default")
                 .queryParam("limit", limit)
                 .when()
@@ -104,10 +107,11 @@ class RESTfulGatewayWfSpecTest {
                 .get("/gateway/tenants/{tenant}/wf-specs")
                 .then()
                 .statusCode(200)
-                .body("results", hasSize(2))
+                .body("results", hasSize(3))
                 .body("bookmark", is(nullValue()))
-                .body("results[0].name", is("json"))
-                .body("results[1].name", is("workflow-in-a-bean"))
+                .body("results[0].name", is("nested-grandparent-wf"))
+                .body("results[1].name", is("nested-parent-wf"))
+                .body("results[2].name", is("workflow-in-a-bean"))
                 .log()
                 .all();
     }

--- a/integration-tests/src/integrationTest/java/io/littlehorse/test/WorkflowRegistrationTest.java
+++ b/integration-tests/src/integrationTest/java/io/littlehorse/test/WorkflowRegistrationTest.java
@@ -42,15 +42,25 @@ class WorkflowRegistrationTest {
                     WfSpecId greetings =
                             WfSpecId.newBuilder().setName("greetings").build();
                     WfSpecId json = WfSpecId.newBuilder().setName("json").build();
+                    WfSpecId nestedChildWf =
+                            WfSpecId.newBuilder().setName("nested-child-wf").build();
+                    WfSpecId nestedGrandparentWf = WfSpecId.newBuilder()
+                            .setName("nested-grandparent-wf")
+                            .build();
+                    WfSpecId nestedParentWf =
+                            WfSpecId.newBuilder().setName("nested-parent-wf").build();
                     WfSpecId beanWorkflow =
                             WfSpecId.newBuilder().setName("workflow-in-a-bean").build();
                     WfSpecIdList expectedResult = WfSpecIdList.newBuilder()
                             .addResults(typeAdapter)
                             .addResults(greetings)
                             .addResults(json)
+                            .addResults(nestedChildWf)
+                            .addResults(nestedGrandparentWf)
+                            .addResults(nestedParentWf)
                             .addResults(beanWorkflow)
                             .build();
-                    assertThat(results.getResultsCount()).isEqualTo(4);
+                    assertThat(results.getResultsCount()).isEqualTo(7);
                     assertThat(results).isEqualTo(expectedResult);
 
                     Stream.of(

--- a/integration-tests/src/main/java/io/littlehorse/workflows/NestedChildWorkflows.java
+++ b/integration-tests/src/main/java/io/littlehorse/workflows/NestedChildWorkflows.java
@@ -1,0 +1,36 @@
+package io.littlehorse.workflows;
+
+import static io.littlehorse.tasks.GreetingsTask.GREETINGS_TASK;
+
+import io.littlehorse.quarkus.workflow.LHWorkflow;
+import io.littlehorse.sdk.wfsdk.SpawnedChildWf;
+import io.littlehorse.sdk.wfsdk.WorkflowThread;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Map;
+
+@ApplicationScoped
+public class NestedChildWorkflows {
+
+    public static final String GRANDPARENT_WF = "nested-grandparent-wf";
+    public static final String PARENT_WF = "nested-parent-wf";
+    public static final String CHILD_WF = "nested-child-wf";
+
+    @LHWorkflow(GRANDPARENT_WF)
+    public void grandparent(WorkflowThread wf) {
+        SpawnedChildWf childRun = wf.runWf(PARENT_WF, Map.of());
+        wf.waitForChildWf(childRun);
+    }
+
+    @LHWorkflow(PARENT_WF)
+    public void parent(WorkflowThread wf) {
+        SpawnedChildWf childRun = wf.runWf(CHILD_WF, Map.of());
+        wf.waitForChildWf(childRun);
+    }
+
+    @LHWorkflow(CHILD_WF)
+    public void child(WorkflowThread wf) {
+        wf.execute(GREETINGS_TASK, "nested-child");
+    }
+}


### PR DESCRIPTION
- LHWorkflowRecordable.dependencies() now returns both the parent wf and all required child wf spec names from wf.getRequiredChildWfSpecNames(), ensuring the dependency graph covers all related workflows

Assisted-by: Claude Sonnet 4.6