### PR TITLE
feat(structs): add inline struct support example and integration coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Quarkus extensions for the [LittleHorse](https://littlehorse.io/) workflow engin
 - `extensions/littlehorse-restful-gateway/` — RESTful gateway extension (runtime + deployment)
 - `extensions/littlehorse-saddle-bag/` — Saddle Bag extension for self-describing task worker Docker images (runtime + deployment)
 - `extras/restful-gateway/` — Standalone Quarkus app using the gateway extension
-- `examples/` — Usage examples (arrays-maps, basic, child-workflow, reactive, rest, saddle-bag, structs, type-adapter, user-tasks)
+- `examples/` — Usage examples (arrays-maps, basic, child-workflow, inline-structs, reactive, rest, saddle-bag, structs, type-adapter, user-tasks)
 - `integration-tests/` — End-to-end tests against a running LittleHorse instance, split per concern into subprojects named after the extension they cover: `littlehorse-quarkus/` (project `integration-tests-littlehorse-quarkus`), `littlehorse-restful-gateway/` (project `integration-tests-littlehorse-restful-gateway`), `littlehorse-saddle-bag/` (project `integration-tests-littlehorse-saddle-bag`)
 
 Each extension follows the Quarkus extension structure: `deployment/` for build-time processors, `runtime/` for CDI beans and recorders.
@@ -24,13 +24,13 @@ Each extension follows the Quarkus extension structure: `deployment/` for build-
 # Unit tests
 ./gradlew test
 
-# Integration tests (requires ./gradlew dockerComposeUp)
+# Integration tests (requires Docker; the tests start LittleHorse with Testcontainers)
 ./gradlew integration-tests-littlehorse-quarkus:quarkusIntTest integration-tests-littlehorse-restful-gateway:quarkusIntTest integration-tests-littlehorse-saddle-bag:quarkusIntTest
 
 # Native integration tests
 ./gradlew integration-tests-littlehorse-quarkus:quarkusIntTest integration-tests-littlehorse-restful-gateway:quarkusIntTest integration-tests-littlehorse-saddle-bag:quarkusIntTest -Dquarkus.native.enabled=true -Dquarkus.package.jar.enabled=false
 
-# Publish locally (version=dev)
+# Publish locally (uses the version from gradle.properties)
 ./gradlew publishToMavenLocal
 
 # Run RESTful Gateway in dev mode
@@ -42,14 +42,21 @@ Each extension follows the Quarkus extension structure: `deployment/` for build-
 - Java 17
 - Palantir Java Format (AOSP style) enforced via Spotless
 - Run `./gradlew spotlessApply` to auto-format before committing
-- Pre-commit hooks are configured — run `pre-commit install` after cloning
+- Pre-commit and commit-message hooks are configured — run `pre-commit install` after cloning
+
+## Commit Messages
+
+- Every commit must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+- Use the format `<type>(<optional scope>): <description>` (for example, `feat(examples): add inline structs example`).
+- Use an appropriate standard type: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, or `test`.
+- Mark breaking changes with `!` before the colon or with a `BREAKING CHANGE:` footer.
 
 ## Conventions
 
-- Quarkus version: `3.37.0`, LittleHorse SDK: `1.2-SNAPSHOT`
+- Quarkus version: `3.37.2`, LittleHorse SDK: `1.2-SNAPSHOT`
 - Dependency versions are centralized in `gradle.properties`
-- Extension projects: `quarkus`, `restful-gateway`, `saddle-bag`
-- Example projects: `user-tasks`, `reactive`, `rest`, `basic`, `child-workflow`, `structs`, `type-adapter`, `saddle-bag`, `arrays-maps`
+- Extension projects: `littlehorse-quarkus`, `littlehorse-restful-gateway`, `littlehorse-saddle-bag` (each also has a `-deployment` project)
+- Example projects use the `example-` prefix: `example-arrays-maps`, `example-basic`, `example-child-workflow`, `example-inline-structs`, `example-reactive`, `example-rest`, `example-saddle-bag`, `example-structs`, `example-type-adapter`, `example-user-tasks`
 - Use `@LHTaskMethod` and related annotations for task/workflow registration
 - Use `@LHTaskConfig` to declare required external configurations for Saddle Bag manifests
 - Deployment processors scan annotations at build time — runtime beans are produced via recorders

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - [Saddle Bag](examples/saddle-bag): How to create a saddle bag.
 - [User Tasks](examples/user-tasks): How to use and register user tasks.
 - [Structs](examples/structs): How to use and register structs.
+- [Inline Structs](examples/inline-structs): How to use raw inline structs with configured StructDef names.
 - [Type Adapters](examples/type-adapter): How to use and register type adapters.
 - [Arrays & Maps](examples/arrays-maps): How to use native `Array` and `Map` types.
 

--- a/examples/inline-structs/README.md
+++ b/examples/inline-structs/README.md
@@ -1,0 +1,75 @@
+# Inline Structs Example
+
+This example shows how to use inline structs whose `StructDef` names are supplied through
+Quarkus configuration. The `Customer` class uses a placeholder in `@LHStructDef`:
+
+Raw `InlineStruct` values are intended for advanced cases where task code needs to work with the
+protobuf value directly. When the Java type is known, prefer the typed approach shown in the
+[Structs example](../structs).
+
+```java
+@LHStructDef("${customer.struct.name}")
+public class Customer {
+    // fields, constructors, getters, and setters
+}
+```
+
+The placeholder is configured in `application.properties`:
+
+```properties
+customer.struct.name=customer-acme
+```
+
+The LittleHorse Quarkus extension resolves the placeholder and registers the resulting
+`customer-acme` `StructDef`. The workflow and task signatures use the same placeholder value. The
+workflow runs two tasks: `create-customer` returns a raw `InlineStruct`, and `email-customer`
+receives it. The task return and parameter bind the raw value to the registered StructDef with
+`@LHType(structDefName = "${customer.struct.name}")`.
+
+```java
+@LHTaskMethod("create-customer")
+@LHType(structDefName = "${customer.struct.name}")
+public InlineStruct createCustomer(String name, String email) {
+    return InlineStruct.newBuilder()
+            // Add fields compatible with the Customer StructDef.
+            .build();
+}
+
+@LHTaskMethod("email-customer")
+public String emailCustomer(
+        @LHType(structDefName = "${customer.struct.name}") InlineStruct customer,
+        String message) {
+    String email = customer.getFieldsOrThrow("email").getValue().getStr();
+    return "Sent to " + email;
+}
+```
+
+The extension carries the placeholder value from the scanned `@LHStructDef` into task
+registration and runtime input/output serialization. The same placeholder therefore needs to be
+used by the StructDef and the `@LHType` annotations.
+
+## Running the Example
+
+Start LittleHorse:
+
+```shell
+./gradlew dockerComposeUp
+```
+
+Run the example:
+
+```shell
+./gradlew example-inline-structs:quarkusDev
+```
+
+Start a workflow run:
+
+```shell
+lhctl run inline-structs name Leia email leia@rebellion.example message 'Welcome to LittleHorse'
+```
+
+Inspect workflow runs:
+
+```shell
+lhctl search wfRun inline-structs
+```

--- a/examples/inline-structs/build.gradle
+++ b/examples/inline-structs/build.gradle
@@ -1,0 +1,11 @@
+dependencies {
+    // quarkus
+    implementation enforcedPlatform("io.quarkus.platform:quarkus-bom:${quarkusVersion}")
+    implementation "io.quarkus:quarkus-arc"
+
+    // quarkus extension
+    implementation project(":littlehorse-quarkus")
+
+    // logs
+    implementation "org.jboss.slf4j:slf4j-jboss-logmanager"
+}

--- a/examples/inline-structs/src/main/java/io/littlehorse/structs/Customer.java
+++ b/examples/inline-structs/src/main/java/io/littlehorse/structs/Customer.java
@@ -1,0 +1,48 @@
+package io.littlehorse.structs;
+
+import io.littlehorse.sdk.worker.LHStructDef;
+
+@LHStructDef("${customer.struct.name}")
+public class Customer {
+
+    private String id;
+    private String name;
+    private String email;
+
+    public Customer() {}
+
+    public Customer(String id, String name, String email) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    @Override
+    public String toString() {
+        return "Customer{id='%s', name='%s', email='%s'}".formatted(id, name, email);
+    }
+}

--- a/examples/inline-structs/src/main/java/io/littlehorse/tasks/InlineStructTasks.java
+++ b/examples/inline-structs/src/main/java/io/littlehorse/tasks/InlineStructTasks.java
@@ -1,0 +1,74 @@
+package io.littlehorse.tasks;
+
+import io.littlehorse.quarkus.task.LHTask;
+import io.littlehorse.quarkus.workflow.LHWorkflow;
+import io.littlehorse.sdk.common.proto.InlineStruct;
+import io.littlehorse.sdk.common.proto.StructField;
+import io.littlehorse.sdk.common.proto.VariableValue;
+import io.littlehorse.sdk.wfsdk.WfRunVariable;
+import io.littlehorse.sdk.wfsdk.WorkflowThread;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+import io.littlehorse.sdk.worker.LHType;
+import io.littlehorse.structs.Customer;
+
+import java.util.UUID;
+
+@LHTask
+public class InlineStructTasks {
+
+    public static final String WORKFLOW_NAME = "inline-structs";
+    public static final String CREATE_CUSTOMER_TASK = "create-customer";
+    public static final String EMAIL_CUSTOMER_TASK = "email-customer";
+    public static final String NAME_VAR = "name";
+    public static final String EMAIL_VAR = "email";
+    public static final String MESSAGE_VAR = "message";
+    public static final String CUSTOMER_VAR = "customer";
+
+    @LHWorkflow(WORKFLOW_NAME)
+    public void workflow(WorkflowThread wf) {
+        WfRunVariable name = wf.declareStr(NAME_VAR).required();
+        WfRunVariable email = wf.declareStr(EMAIL_VAR).required();
+        WfRunVariable message = wf.declareStr(MESSAGE_VAR).required();
+        WfRunVariable customer = wf.declareStruct(CUSTOMER_VAR, Customer.class);
+
+        customer.assign(wf.execute(CREATE_CUSTOMER_TASK, name, email));
+        wf.execute(EMAIL_CUSTOMER_TASK, customer, message);
+    }
+
+    @LHTaskMethod(
+            value = CREATE_CUSTOMER_TASK,
+            description = "Creates and returns an inline Customer struct.")
+    @LHType(structDefName = "${customer.struct.name}")
+    public InlineStruct createCustomer(String name, String email) {
+        return InlineStruct.newBuilder()
+                .putFields(
+                        "id",
+                        StructField.newBuilder()
+                                .setValue(VariableValue.newBuilder()
+                                        .setStr(UUID.randomUUID().toString()))
+                                .build())
+                .putFields(
+                        "name",
+                        StructField.newBuilder()
+                                .setValue(VariableValue.newBuilder().setStr(name))
+                                .build())
+                .putFields(
+                        "email",
+                        StructField.newBuilder()
+                                .setValue(VariableValue.newBuilder().setStr(email))
+                                .build())
+                .build();
+    }
+
+    @LHTaskMethod(
+            value = EMAIL_CUSTOMER_TASK,
+            description = "Receives an inline Customer struct and sends it a message.")
+    public String emailCustomer(
+            @LHType(structDefName = "${customer.struct.name}") InlineStruct customer,
+            String message) {
+        String name = customer.getFieldsOrThrow("name").getValue().getStr();
+        String email = customer.getFieldsOrThrow("email").getValue().getStr();
+        System.out.printf("Sending '%s' to %s <%s>%n", message, name, email);
+        return "sent";
+    }
+}

--- a/examples/inline-structs/src/main/resources/application.properties
+++ b/examples/inline-structs/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+customer.struct.name=customer-acme

--- a/examples/structs/README.md
+++ b/examples/structs/README.md
@@ -64,7 +64,7 @@ Setup:
 Execute it:
 
 ```shell
-./gradlew example-struct:quarkusDev
+./gradlew example-structs:quarkusDev
 ```
 
 Run workflow:

--- a/extensions/littlehorse-quarkus/README.md
+++ b/extensions/littlehorse-quarkus/README.md
@@ -14,6 +14,8 @@ This is the base Quarkus extension for [LittleHorse](https://littlehorse.io/).
   * [Registering a Workflow](#registering-a-workflow)
   * [Registering User Tasks](#registering-user-tasks)
   * [Registering Structs](#registering-structs)
+    * [Configured StructDef Names](#configured-structdef-names)
+    * [Raw InlineStruct Values](#raw-inlinestruct-values)
   * [Registering Type Adapters](#registering-type-adapters)
   * [LittleHorse Clients](#littlehorse-clients)
   * [Dependency Injection](#dependency-injection)
@@ -299,6 +301,60 @@ public class Person {
 
 Quarkus will register the [StructDef](https://littlehorse.io/docs/server/concepts/structdefs#define-the-structdef)
 when starting the application.
+
+### Configured StructDef Names
+
+The `@LHStructDef` name may contain a configuration expression. This is useful when the deployed
+StructDef name is not known when the application is compiled:
+
+```java
+@LHStructDef("${customer.struct.name}")
+public class Customer {
+    // fields, constructors, getters, and setters
+}
+```
+
+Supply the value through any Quarkus configuration source, for example
+`application.properties`:
+
+```properties
+customer.struct.name=customer-acme
+```
+
+The extension registers the StructDef as `customer-acme` and supplies the same resolved name when
+the class is used by a workflow or task. For example,
+`wf.declareStruct("customer", Customer.class)` declares a variable backed by the
+`customer-acme` StructDef.
+
+### Raw InlineStruct Values
+
+Prefer the annotated Java type for normal StructDef task inputs and outputs. For advanced workers
+that need to handle raw `InlineStruct` values, bind the raw value to a StructDef using
+`@LHType(structDefName = ...)`:
+
+```java
+@LHTaskMethod("create-customer")
+@LHType(structDefName = "${customer.struct.name}")
+public InlineStruct createCustomer(String name, String email) {
+    return InlineStruct.newBuilder()
+            // Add fields compatible with the Customer StructDef.
+            .build();
+}
+
+@LHTaskMethod("email-customer")
+public String emailCustomer(
+        @LHType(structDefName = "${customer.struct.name}") InlineStruct customer,
+        String message) {
+    String email = customer.getFieldsOrThrow("email").getValue().getStr();
+    return "Sent to " + email;
+}
+```
+
+The placeholder used by `@LHType` must match a placeholder available from a scanned
+`@LHStructDef`, such as the `Customer` class above. The extension passes its resolved value through
+task registration, input deserialization, and output serialization.
+
+See the complete [Inline Structs example](../../examples/inline-structs).
 
 More about structs at: [StructDef](https://littlehorse.io/docs/server/concepts/structdefs).
 

--- a/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/InlineStructSerializationTest.java
+++ b/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/InlineStructSerializationTest.java
@@ -1,0 +1,98 @@
+package io.littlehorse.test;
+
+import static io.littlehorse.workflows.InlineStructWorkflow.CUSTOMER_VARIABLE;
+import static io.littlehorse.workflows.InlineStructWorkflow.DELIVERY_VARIABLE;
+import static io.littlehorse.workflows.InlineStructWorkflow.EMAIL_VARIABLE;
+import static io.littlehorse.workflows.InlineStructWorkflow.ID_VARIABLE;
+import static io.littlehorse.workflows.InlineStructWorkflow.INLINE_STRUCT_WORKFLOW;
+import static io.littlehorse.workflows.InlineStructWorkflow.MESSAGE_VARIABLE;
+import static io.littlehorse.workflows.InlineStructWorkflow.NAME_VARIABLE;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.with;
+
+import io.littlehorse.common.ContainersTestResource;
+import io.littlehorse.common.InjectLittleHorseBlockingStub;
+import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.sdk.common.proto.LHStatus;
+import io.littlehorse.sdk.common.proto.ListVariablesRequest;
+import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.RunWfRequest;
+import io.littlehorse.sdk.common.proto.Variable;
+import io.littlehorse.sdk.common.proto.VariableValue;
+import io.littlehorse.sdk.common.proto.WfRun;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+@QuarkusIntegrationTest
+@QuarkusTestResource(ContainersTestResource.class)
+class InlineStructSerializationTest {
+
+    private static final String CUSTOMER_ID = "customer-123";
+    private static final String CUSTOMER_NAME = "Leia";
+    private static final String CUSTOMER_EMAIL = "leia@rebellion.example";
+    private static final String MESSAGE = "Welcome to LittleHorse";
+    private static final String STRUCT_DEF_NAME = "lh-inline-customer";
+
+    @InjectLittleHorseBlockingStub
+    LittleHorseBlockingStub blockingStub;
+
+    @Test
+    void shouldReturnAndReceiveInlineStructWithPlaceholderStructDefName() {
+        WfRun wfRun = blockingStub.runWf(RunWfRequest.newBuilder()
+                .setWfSpecName(INLINE_STRUCT_WORKFLOW)
+                .putVariables(ID_VARIABLE, LHLibUtil.objToVarVal(CUSTOMER_ID))
+                .putVariables(NAME_VARIABLE, LHLibUtil.objToVarVal(CUSTOMER_NAME))
+                .putVariables(EMAIL_VARIABLE, LHLibUtil.objToVarVal(CUSTOMER_EMAIL))
+                .putVariables(MESSAGE_VARIABLE, LHLibUtil.objToVarVal(MESSAGE))
+                .build());
+
+        with().pollInterval(Duration.ofSeconds(1))
+                .ignoreExceptions()
+                .await()
+                .atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> {
+                    WfRun result = blockingStub.getWfRun(wfRun.getId());
+                    assertThat(result.getStatus()).isEqualTo(LHStatus.COMPLETED);
+
+                    List<Variable> variables = blockingStub
+                            .listVariables(ListVariablesRequest.newBuilder()
+                                    .setWfRunId(wfRun.getId())
+                                    .build())
+                            .getResultsList();
+
+                    VariableValue customer = getVariableValue(variables, CUSTOMER_VARIABLE);
+                    assertThat(customer.getStruct().getStructDefId().getName())
+                            .isEqualTo(STRUCT_DEF_NAME);
+                    assertThat(stringField(customer, "id")).isEqualTo(CUSTOMER_ID);
+                    assertThat(stringField(customer, "name")).isEqualTo(CUSTOMER_NAME);
+                    assertThat(stringField(customer, "email")).isEqualTo(CUSTOMER_EMAIL);
+
+                    VariableValue delivery = getVariableValue(variables, DELIVERY_VARIABLE);
+                    assertThat(delivery.getStr())
+                            .isEqualTo("%s <%s>: %s"
+                                    .formatted(CUSTOMER_NAME, CUSTOMER_EMAIL, MESSAGE));
+                });
+    }
+
+    private static VariableValue getVariableValue(List<Variable> variables, String variableName) {
+        return variables.stream()
+                .filter(variable -> variable.getId().getName().equals(variableName))
+                .map(Variable::getValue)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static String stringField(VariableValue struct, String fieldName) {
+        return struct.getStruct()
+                .getStruct()
+                .getFieldsOrThrow(fieldName)
+                .getValue()
+                .getStr();
+    }
+}

--- a/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/StructRegistrationTest.java
+++ b/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/StructRegistrationTest.java
@@ -39,11 +39,14 @@ class StructRegistrationTest {
                                     .setName("lh-address")
                                     .build())
                             .addResults(StructDefId.newBuilder()
+                                    .setName("lh-inline-customer")
+                                    .build())
+                            .addResults(StructDefId.newBuilder()
                                     .setName("lh-person")
                                     .build())
                             .build();
 
-                    assertThat(results.getResultsCount()).isEqualTo(2);
+                    assertThat(results.getResultsCount()).isEqualTo(3);
                     assertThat(results).isEqualTo(expectedResult);
                 });
     }

--- a/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/TaskRegistrationTest.java
+++ b/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/TaskRegistrationTest.java
@@ -39,10 +39,16 @@ class TaskRegistrationTest {
                             .addResults(
                                     TaskDefId.newBuilder().setName("count-map").build())
                             .addResults(TaskDefId.newBuilder()
+                                    .setName("create-inline-customer")
+                                    .build())
+                            .addResults(TaskDefId.newBuilder()
                                     .setName("describe-person")
                                     .build())
                             .addResults(
                                     TaskDefId.newBuilder().setName("echo-uuid").build())
+                            .addResults(TaskDefId.newBuilder()
+                                    .setName("email-inline-customer")
+                                    .build())
                             .addResults(
                                     TaskDefId.newBuilder().setName("get-uuid").build())
                             .addResults(
@@ -61,7 +67,7 @@ class TaskRegistrationTest {
                                     TaskDefId.newBuilder().setName("sum-array").build())
                             .build();
 
-                    assertThat(results.getResultsCount()).isEqualTo(11);
+                    assertThat(results.getResultsCount()).isEqualTo(13);
                     assertThat(results).isEqualTo(expectedResult);
                 });
     }

--- a/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/WorkflowRegistrationTest.java
+++ b/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/WorkflowRegistrationTest.java
@@ -43,6 +43,8 @@ class WorkflowRegistrationTest {
                             WfSpecId.newBuilder().setName("arrays-maps").build();
                     WfSpecId greetings =
                             WfSpecId.newBuilder().setName("greetings").build();
+                    WfSpecId inlineStructs =
+                            WfSpecId.newBuilder().setName("inline-structs").build();
                     WfSpecId json = WfSpecId.newBuilder().setName("json").build();
                     WfSpecId nestedChildWf =
                             WfSpecId.newBuilder().setName("nested-child-wf").build();
@@ -59,6 +61,7 @@ class WorkflowRegistrationTest {
                             .addResults(arraysMaps)
                             .addResults(typeAdapter)
                             .addResults(greetings)
+                            .addResults(inlineStructs)
                             .addResults(json)
                             .addResults(nestedChildWf)
                             .addResults(nestedGrandparentWf)
@@ -66,7 +69,7 @@ class WorkflowRegistrationTest {
                             .addResults(personWf)
                             .addResults(beanWorkflow)
                             .build();
-                    assertThat(results.getResultsCount()).isEqualTo(9);
+                    assertThat(results.getResultsCount()).isEqualTo(10);
                     assertThat(results).isEqualTo(expectedResult);
 
                     Stream.of(

--- a/integration-tests/littlehorse-quarkus/src/main/java/io/littlehorse/structs/InlineCustomer.java
+++ b/integration-tests/littlehorse-quarkus/src/main/java/io/littlehorse/structs/InlineCustomer.java
@@ -1,0 +1,35 @@
+package io.littlehorse.structs;
+
+import io.littlehorse.sdk.worker.LHStructDef;
+
+@LHStructDef("${struct.inline-customer.name}")
+public class InlineCustomer {
+
+    private String id;
+    private String name;
+    private String email;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/integration-tests/littlehorse-quarkus/src/main/java/io/littlehorse/tasks/InlineStructTask.java
+++ b/integration-tests/littlehorse-quarkus/src/main/java/io/littlehorse/tasks/InlineStructTask.java
@@ -1,0 +1,40 @@
+package io.littlehorse.tasks;
+
+import io.littlehorse.quarkus.task.LHTask;
+import io.littlehorse.sdk.common.proto.InlineStruct;
+import io.littlehorse.sdk.common.proto.StructField;
+import io.littlehorse.sdk.common.proto.VariableValue;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+import io.littlehorse.sdk.worker.LHType;
+
+@LHTask
+public class InlineStructTask {
+
+    public static final String CREATE_INLINE_CUSTOMER_TASK = "create-inline-customer";
+    public static final String EMAIL_INLINE_CUSTOMER_TASK = "email-inline-customer";
+    private static final String INLINE_CUSTOMER_STRUCT = "${struct.inline-customer.name}";
+
+    @LHTaskMethod(CREATE_INLINE_CUSTOMER_TASK)
+    @LHType(structDefName = INLINE_CUSTOMER_STRUCT)
+    public InlineStruct createCustomer(String id, String name, String email) {
+        return InlineStruct.newBuilder()
+                .putFields("id", stringField(id))
+                .putFields("name", stringField(name))
+                .putFields("email", stringField(email))
+                .build();
+    }
+
+    @LHTaskMethod(EMAIL_INLINE_CUSTOMER_TASK)
+    public String emailCustomer(
+            @LHType(structDefName = INLINE_CUSTOMER_STRUCT) InlineStruct customer, String message) {
+        String name = customer.getFieldsOrThrow("name").getValue().getStr();
+        String email = customer.getFieldsOrThrow("email").getValue().getStr();
+        return "%s <%s>: %s".formatted(name, email, message);
+    }
+
+    private static StructField stringField(String value) {
+        return StructField.newBuilder()
+                .setValue(VariableValue.newBuilder().setStr(value))
+                .build();
+    }
+}

--- a/integration-tests/littlehorse-quarkus/src/main/java/io/littlehorse/workflows/InlineStructWorkflow.java
+++ b/integration-tests/littlehorse-quarkus/src/main/java/io/littlehorse/workflows/InlineStructWorkflow.java
@@ -1,0 +1,35 @@
+package io.littlehorse.workflows;
+
+import static io.littlehorse.tasks.InlineStructTask.CREATE_INLINE_CUSTOMER_TASK;
+import static io.littlehorse.tasks.InlineStructTask.EMAIL_INLINE_CUSTOMER_TASK;
+
+import io.littlehorse.quarkus.workflow.LHWorkflow;
+import io.littlehorse.quarkus.workflow.LHWorkflowDefinition;
+import io.littlehorse.sdk.wfsdk.WfRunVariable;
+import io.littlehorse.sdk.wfsdk.WorkflowThread;
+import io.littlehorse.structs.InlineCustomer;
+
+@LHWorkflow(InlineStructWorkflow.INLINE_STRUCT_WORKFLOW)
+public class InlineStructWorkflow implements LHWorkflowDefinition {
+
+    public static final String INLINE_STRUCT_WORKFLOW = "inline-structs";
+    public static final String ID_VARIABLE = "id";
+    public static final String NAME_VARIABLE = "name";
+    public static final String EMAIL_VARIABLE = "email";
+    public static final String MESSAGE_VARIABLE = "message";
+    public static final String CUSTOMER_VARIABLE = "customer";
+    public static final String DELIVERY_VARIABLE = "delivery";
+
+    @Override
+    public void define(WorkflowThread wf) {
+        WfRunVariable id = wf.declareStr(ID_VARIABLE).required();
+        WfRunVariable name = wf.declareStr(NAME_VARIABLE).required();
+        WfRunVariable email = wf.declareStr(EMAIL_VARIABLE).required();
+        WfRunVariable message = wf.declareStr(MESSAGE_VARIABLE).required();
+        WfRunVariable customer = wf.declareStruct(CUSTOMER_VARIABLE, InlineCustomer.class);
+        WfRunVariable delivery = wf.declareStr(DELIVERY_VARIABLE);
+
+        customer.assign(wf.execute(CREATE_INLINE_CUSTOMER_TASK, id, name, email));
+        delivery.assign(wf.execute(EMAIL_INLINE_CUSTOMER_TASK, customer, message));
+    }
+}

--- a/integration-tests/littlehorse-quarkus/src/main/resources/application.properties
+++ b/integration-tests/littlehorse-quarkus/src/main/resources/application.properties
@@ -4,3 +4,4 @@ retry.max.delay.ms=5000
 retry.multiplier=2.2
 struct.person.name=lh-person
 struct.address.name=lh-address
+struct.inline-customer.name=lh-inline-customer


### PR DESCRIPTION
## Summary

- Add an inline structs example using configured `StructDef` names and raw `InlineStruct` task values.
- Document configured struct names and raw inline struct serialization.
- Add integration coverage for registration, serialization, and workflow execution.
- Correct the structs example Gradle task name.

## Testing

- Added integration tests covering inline struct registration and end-to-end serialization.