### PR TITLE
fix(quarkus): resolve placeholders in LHType annotations

### DIFF
--- a/extensions/littlehorse-quarkus/README.md
+++ b/extensions/littlehorse-quarkus/README.md
@@ -304,8 +304,8 @@ when starting the application.
 
 ### Configured StructDef Names
 
-The `@LHStructDef` name may contain a configuration expression. This is useful when the deployed
-StructDef name is not known when the application is compiled:
+The `@LHStructDef` name may contain a LittleHorse SDK placeholder template. This is useful when the
+deployed StructDef name is not known when the application is compiled:
 
 ```java
 @LHStructDef("${customer.struct.name}")
@@ -350,8 +350,9 @@ public String emailCustomer(
 }
 ```
 
-The extension resolves `@LHType.structDefName` expressions directly from any Quarkus configuration
-source. The referenced StructDefs do not need corresponding local `@LHStructDef` classes:
+The extension records `@LHType.structDefName` templates at build time and supplies their
+placeholder values from any Quarkus configuration source when constructing the worker. The
+referenced StructDefs do not need corresponding local `@LHStructDef` classes:
 
 ```properties
 customer.request.struct.name=external-customer-request
@@ -362,11 +363,15 @@ This only supplies the StructDef names used for task registration, input deseria
 output serialization. It does not register synthetic StructDefs; externally defined StructDefs
 remain owned and registered by the consuming application.
 
-Configuration-expression defaults are also supported, for example
-`@LHType(structDefName = "${customer.struct.name:customer}")`. If the same placeholder appears in
-multiple task annotation locations, matching resolved values are reused. Conflicting resolved
-values fail startup, and a missing value without a default reports the missing configuration key.
-Placeholders supplied by scanned `@LHStructDef` classes continue to work as before.
+`@LHType.structDefName` follows the LittleHorse SDK placeholder syntax and supports
+`${placeholder}` expressions. SDK-owned worker annotations do not support configuration-expression
+defaults such as `${placeholder:default}`. This applies consistently to `@LHType`,
+`@LHTaskMethod`, and `@LHStructDef`.
+
+If the same placeholder appears in multiple task annotation locations, matching resolved values
+are reused. Conflicting resolved values fail startup, and a missing value reports the missing
+configuration key. Placeholders supplied by scanned `@LHStructDef` classes continue to work as
+before.
 
 See the complete [Inline Structs example](../../examples/inline-structs).
 
@@ -375,7 +380,7 @@ More about structs at: [StructDef](https://littlehorse.io/docs/server/concepts/s
 ## Registering Type Adapters
 
 Type Adapters allow the LittleHorse SDK to convert between your types and LittleHorse's native typing system.
-Check available type adapters at [Type Adapter Interfaces](https://littlehorse.io/next/docs/server/developer-guide/sdk-type-adapters#type-adapter-interfaces).
+Check available type adapters at [Type Adapter Interfaces](https://littlehorse.io/docs/server/developer-guide/sdk-type-adapters#type-adapter-interfaces).
 
 Annotate a type adapter class with the `@LHTypeAdapter` annotation specifying the target `VariableType` and the adapted Java class. Quarkus will register the type adapter for you. Example:
 
@@ -400,7 +405,7 @@ public class UUIDTypeAdapter implements LHStringAdapter<UUID> {
 }
 ```
 
-More about type adapters at : [SDK Type Adapters](https://littlehorse.io/next/docs/server/developer-guide/sdk-type-adapters).
+More about type adapters at: [SDK Type Adapters](https://littlehorse.io/docs/server/developer-guide/sdk-type-adapters).
 
 ## LittleHorse Clients
 
@@ -453,8 +458,11 @@ public class GreetingsResource {
 
 ## Dependency Injection
 
-Objects annotated with `@LHTask`, `@LHUserTaskForm` o `@LHWorkflow` are marked as beans and are managed by the Quarkus
-[CDI](https://quarkus.io/guides/cdi), so it is possible to inject other beans into them.
+Classes annotated with `@LHTask`, `@LHWorkflow`, `@LHUserTaskForm`, `@LHStructDef`, or
+`@LHTypeAdapter` are marked as beans and managed by Quarkus
+[CDI](https://quarkus.io/guides/cdi), so it is possible to inject other beans into them. A class
+that declares a method-level `@LHWorkflow` must otherwise be a CDI bean, for example by adding
+`@ApplicationScoped`.
 
 ```java
 @LHTask
@@ -478,8 +486,8 @@ Add `quarkus-smallrye-health` to your project.
 implementation "io.quarkus:quarkus-smallrye-health"
 ```
 
-This extension will automatically add all [LHTaskWorker::healthStatus](https://github.com/littlehorse-enterprises/littlehorse/blob/master/sdk-java/src/main/java/io/littlehorse/sdk/worker/LHTaskWorker.java#L254)
-to the quarkus health checks.
+This extension automatically contributes the health status of every managed `LHTaskWorker` to the
+Quarkus health checks.
 
 To disable this feature, you have to pass `quarkus.littlehorse.health.enabled=false`
 config at build time (either `jar` or `native`). Example:
@@ -488,7 +496,7 @@ config at build time (either `jar` or `native`). Example:
 ./gradlew build -Dquarkus.littlehorse.health.enabled=false
 ```
 
-More about quarkus healthy checks at: [Smallrey Health](https://quarkus.io/guides/smallrye-health).
+More about Quarkus health checks at: [SmallRye Health](https://quarkus.io/guides/smallrye-health).
 
 ## Native Build
 
@@ -517,8 +525,9 @@ dependencies {
 }
 ```
 
-Then we need to create a [QuarkusTestResourceLifecycleManager](https://quarkus.io/guides/getting-started-testing#launching-containers)
-class, and start LittleHorse:
+Create a
+[QuarkusTestResourceLifecycleManager](https://quarkus.io/guides/getting-started-testing#starting-services-before-the-quarkus-application-starts)
+and start LittleHorse:
 
 ```java
 public class ContainersTestResource implements QuarkusTestResourceLifecycleManager {
@@ -541,7 +550,7 @@ public class ContainersTestResource implements QuarkusTestResourceLifecycleManag
 }
 ```
 
-Add the test resource at your test:
+Add the test resource to your test:
 
 ```java
 @QuarkusTest
@@ -576,14 +585,16 @@ More about tests at: [Testing Your Quarkus Application](https://quarkus.io/guide
 
 ## Transactional LHTaskMethod
 
-It is very common to persist data into relational databases inside `@LHTaskMethods`.
-It is also very common to use framework like [Hibernate](https://quarkus.io/guides/hibernate-orm),
+It is very common to persist data into relational databases inside methods annotated with
+`@LHTaskMethod`. It is also common to use frameworks like
+[Hibernate](https://quarkus.io/guides/hibernate-orm),
 or, in the case of Quarkus, [Panache](https://quarkus.io/guides/hibernate-orm-panache).
 
-As it is now, every `@LHTaskMethod` needs an [LHTaskWorker](https://littlehorse.io/docs/server/developer-guide/task-worker-development)
-which are created and managed by the LH Quarkus extension. An LHTaskWorker runs inside
-its own thread and outside the Quarkus CDI (read more at [Manage Non-CDI Service](https://quarkus.io/guides/writing-extensions#manage-non-cdi-service)).
-Therefore, you could receive `ContextNotActiveException`, example:
+Every `@LHTaskMethod` needs an
+[LHTaskWorker](https://littlehorse.io/docs/server/developer-guide/task-worker-development), which
+is created and managed by the LittleHorse Quarkus extension. Workers invoke task methods on their
+own threads, where request and transaction contexts are not automatically active. Therefore, you
+could receive a `ContextNotActiveException`, for example:
 
 ```
 jakarta.enterprise.context.ContextNotActiveException: Cannot use the EntityManager/Session because neither
@@ -677,12 +688,17 @@ Some examples could be:
 This extension supports [Expressions Expansion](https://smallrye.io/smallrye-config/Main/config/expressions/)
 for configurations.
 
-An expression string is a mix of plain strings and expression segments, which are wrapped by the sequence: `${ … }`.
-Additionally, the Expression Expansion engine supports the following segments:
+For values evaluated directly by the Quarkus extension, an expression string is a mix of plain
+strings and expression segments wrapped by the sequence `${ … }`. The expression expansion engine
+supports the following segments. This applies to `@LHWorkflow`, its nested
+`@LHExponentialBackoffRetry`, and `@LHUserTaskForm` values:
 
 `${expression:value}` - Provides a default value after the `:` if the expansion doesn’t find a value.
 `${my.prop${compose}}` - Composed expressions. Inner expressions are resolved first.
 `${my.prop}${my.prop}` - Multiple expressions.
+
+The LittleHorse SDK-owned `@LHTaskMethod`, `@LHStructDef`, and `@LHType` annotations support plain
+`${placeholder}` substitution only, as described in [Raw InlineStruct Values](#raw-inlinestruct-values).
 
 Examples:
 
@@ -726,12 +742,14 @@ and [Configuring the Clients](https://littlehorse.io/docs/server/developer-guide
 The bootstrap host for the LittleHorse Server.
 
 * Type: string
+* Default: localhost
 * Importance: high
 
 ``lhc.api.port``
 The bootstrap port for the LittleHorse Server.
 
 * Type: int
+* Default: 2023
 * Importance: high
 
 ``lhc.api.protocol``
@@ -784,6 +802,20 @@ Time in milliseconds to configure the timeout for the keepalive pings on the grp
 * Default: 5000 (5 seconds)
 * Importance: low
 
+``lhc.grpc.resource.exhausted.retry``
+Enables transparent retries for unary gRPC calls rejected with `RESOURCE_EXHAUSTED`.
+
+* Type: boolean
+* Default: true
+* Importance: low
+
+``lhc.inflight.tasks``
+The maximum number of in-flight tasks per polling thread.
+
+* Type: int
+* Default: 1
+* Importance: medium
+
 ``lhc.oauth.access.token.url``
 Optional Access Token URL provided by the OAuth Authorization Server. Used by the Worker to obtain a token using client credentials flow.
 
@@ -811,7 +843,7 @@ Optional OAuth2 Client Secret. Used by the Worker to identify itself at an Autho
 The number of worker threads to run. It allows you to improve the task execution's performance parallelizing the tasks assigned to this worker.
 
 * Type: int
-* Default: 8
+* Default: 2
 * Importance: medium
 
 ``lhw.task.worker.id``

--- a/extensions/littlehorse-quarkus/README.md
+++ b/extensions/littlehorse-quarkus/README.md
@@ -334,7 +334,7 @@ that need to handle raw `InlineStruct` values, bind the raw value to a StructDef
 
 ```java
 @LHTaskMethod("create-customer")
-@LHType(structDefName = "${customer.struct.name}")
+@LHType(structDefName = "${customer.response.struct.name}")
 public InlineStruct createCustomer(String name, String email) {
     return InlineStruct.newBuilder()
             // Add fields compatible with the Customer StructDef.
@@ -343,16 +343,30 @@ public InlineStruct createCustomer(String name, String email) {
 
 @LHTaskMethod("email-customer")
 public String emailCustomer(
-        @LHType(structDefName = "${customer.struct.name}") InlineStruct customer,
+        @LHType(structDefName = "${customer.request.struct.name}") InlineStruct customer,
         String message) {
     String email = customer.getFieldsOrThrow("email").getValue().getStr();
     return "Sent to " + email;
 }
 ```
 
-The placeholder used by `@LHType` must match a placeholder available from a scanned
-`@LHStructDef`, such as the `Customer` class above. The extension passes its resolved value through
-task registration, input deserialization, and output serialization.
+The extension resolves `@LHType.structDefName` expressions directly from any Quarkus configuration
+source. The referenced StructDefs do not need corresponding local `@LHStructDef` classes:
+
+```properties
+customer.request.struct.name=external-customer-request
+customer.response.struct.name=external-customer-response
+```
+
+This only supplies the StructDef names used for task registration, input deserialization, and
+output serialization. It does not register synthetic StructDefs; externally defined StructDefs
+remain owned and registered by the consuming application.
+
+Configuration-expression defaults are also supported, for example
+`@LHType(structDefName = "${customer.struct.name:customer}")`. If the same placeholder appears in
+multiple task annotation locations, matching resolved values are reused. Conflicting resolved
+values fail startup, and a missing value without a default reports the missing configuration key.
+Placeholders supplied by scanned `@LHStructDef` classes continue to work as before.
 
 See the complete [Inline Structs example](../../examples/inline-structs).
 

--- a/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/item/LHTaskMethodBuildItem.java
+++ b/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/item/LHTaskMethodBuildItem.java
@@ -9,7 +9,7 @@ import java.util.List;
 public final class LHTaskMethodBuildItem extends MultiBuildItem {
     private final Class<?> beanClass;
     private final LHTaskMethodDescriptor descriptor;
-    private final List<String> structDefNameExpressions;
+    private final List<String> structDefNameTemplates;
 
     public LHTaskMethodBuildItem(Class<?> beanClass, LHTaskMethodDescriptor descriptor) {
         this(beanClass, descriptor, List.of());
@@ -18,10 +18,10 @@ public final class LHTaskMethodBuildItem extends MultiBuildItem {
     public LHTaskMethodBuildItem(
             Class<?> beanClass,
             LHTaskMethodDescriptor descriptor,
-            List<String> structDefNameExpressions) {
+            List<String> structDefNameTemplates) {
         this.descriptor = descriptor;
         this.beanClass = beanClass;
-        this.structDefNameExpressions = List.copyOf(structDefNameExpressions);
+        this.structDefNameTemplates = List.copyOf(structDefNameTemplates);
     }
 
     public LHTaskMethodRecordable toRecordable() {
@@ -29,6 +29,6 @@ public final class LHTaskMethodBuildItem extends MultiBuildItem {
                 beanClass,
                 descriptor.getTaskDefName(),
                 descriptor.getDescription(),
-                structDefNameExpressions);
+                structDefNameTemplates);
     }
 }

--- a/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/item/LHTaskMethodBuildItem.java
+++ b/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/item/LHTaskMethodBuildItem.java
@@ -4,17 +4,31 @@ import io.littlehorse.quarkus.deployment.descriptor.LHTaskMethodDescriptor;
 import io.littlehorse.quarkus.runtime.recordable.LHTaskMethodRecordable;
 import io.quarkus.builder.item.MultiBuildItem;
 
+import java.util.List;
+
 public final class LHTaskMethodBuildItem extends MultiBuildItem {
     private final Class<?> beanClass;
     private final LHTaskMethodDescriptor descriptor;
+    private final List<String> structDefNameExpressions;
 
     public LHTaskMethodBuildItem(Class<?> beanClass, LHTaskMethodDescriptor descriptor) {
+        this(beanClass, descriptor, List.of());
+    }
+
+    public LHTaskMethodBuildItem(
+            Class<?> beanClass,
+            LHTaskMethodDescriptor descriptor,
+            List<String> structDefNameExpressions) {
         this.descriptor = descriptor;
         this.beanClass = beanClass;
+        this.structDefNameExpressions = List.copyOf(structDefNameExpressions);
     }
 
     public LHTaskMethodRecordable toRecordable() {
         return new LHTaskMethodRecordable(
-                beanClass, descriptor.getTaskDefName(), descriptor.getDescription());
+                beanClass,
+                descriptor.getTaskDefName(),
+                descriptor.getDescription(),
+                structDefNameExpressions);
     }
 }

--- a/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/item/LHTaskMethodBuildItem.java
+++ b/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/item/LHTaskMethodBuildItem.java
@@ -4,24 +4,24 @@ import io.littlehorse.quarkus.deployment.descriptor.LHTaskMethodDescriptor;
 import io.littlehorse.quarkus.runtime.recordable.LHTaskMethodRecordable;
 import io.quarkus.builder.item.MultiBuildItem;
 
-import java.util.List;
+import java.util.Set;
 
 public final class LHTaskMethodBuildItem extends MultiBuildItem {
     private final Class<?> beanClass;
     private final LHTaskMethodDescriptor descriptor;
-    private final List<String> structDefNameTemplates;
+    private final Set<String> structDefNameTemplates;
 
     public LHTaskMethodBuildItem(Class<?> beanClass, LHTaskMethodDescriptor descriptor) {
-        this(beanClass, descriptor, List.of());
+        this(beanClass, descriptor, Set.of());
     }
 
     public LHTaskMethodBuildItem(
             Class<?> beanClass,
             LHTaskMethodDescriptor descriptor,
-            List<String> structDefNameTemplates) {
+            Set<String> structDefNameTemplates) {
         this.descriptor = descriptor;
         this.beanClass = beanClass;
-        this.structDefNameTemplates = List.copyOf(structDefNameTemplates);
+        this.structDefNameTemplates = Set.copyOf(structDefNameTemplates);
     }
 
     public LHTaskMethodRecordable toRecordable() {

--- a/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
+++ b/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
@@ -55,12 +55,12 @@ class LHServiceProcessor {
                     return new LHTaskMethodBuildItem(
                             beanClass,
                             new LHTaskMethodDescriptor(new OptionalAnnotation(annotated)),
-                            getStructDefNameExpressions(methodInfo));
+                            getStructDefNameTemplates(methodInfo));
                 })
                 .forEach(producer::produce);
     }
 
-    static List<String> getStructDefNameExpressions(MethodInfo methodInfo) {
+    static List<String> getStructDefNameTemplates(MethodInfo methodInfo) {
         return methodInfo.annotations(LH_TYPE).stream()
                 .map(annotation -> annotation.value("structDefName"))
                 .filter(value -> value != null && "structDefName".equals(value.name()))

--- a/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
+++ b/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
@@ -42,6 +42,8 @@ import java.util.stream.Collectors;
 
 class LHServiceProcessor {
 
+    private static final String STRUCT_DEF_NAME = "structDefName";
+
     @BuildStep
     void scanLHTaskMethod(
             BuildProducer<LHTaskMethodBuildItem> producer,
@@ -62,8 +64,8 @@ class LHServiceProcessor {
 
     private static Set<String> getStructDefNameTemplates(MethodInfo methodInfo) {
         return methodInfo.annotations(LHType.class).stream()
-                .map(annotation -> annotation.value("structDefName"))
-                .filter(value -> value != null && "structDefName".equals(value.name()))
+                .map(annotation -> annotation.value(STRUCT_DEF_NAME))
+                .filter(value -> value != null && STRUCT_DEF_NAME.equals(value.name()))
                 .map(value -> value.asString())
                 .filter(value -> !value.isBlank())
                 .collect(Collectors.toUnmodifiableSet());

--- a/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
+++ b/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
@@ -23,6 +23,7 @@ import io.littlehorse.quarkus.workflow.LHWorkflow;
 import io.littlehorse.quarkus.workflow.LHWorkflowDefinition;
 import io.littlehorse.sdk.worker.LHStructDef;
 import io.littlehorse.sdk.worker.LHTaskMethod;
+import io.littlehorse.sdk.worker.LHType;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -39,6 +40,8 @@ import java.util.List;
 
 class LHServiceProcessor {
 
+    private static final DotName LH_TYPE = DotName.createSimple(LHType.class);
+
     @BuildStep
     void scanLHTaskMethod(
             BuildProducer<LHTaskMethodBuildItem> producer,
@@ -51,9 +54,21 @@ class LHServiceProcessor {
                     Class<?> beanClass = ClassLoadingUtils.loadClass(beanClassName);
                     return new LHTaskMethodBuildItem(
                             beanClass,
-                            new LHTaskMethodDescriptor(new OptionalAnnotation(annotated)));
+                            new LHTaskMethodDescriptor(new OptionalAnnotation(annotated)),
+                            getStructDefNameExpressions(methodInfo));
                 })
                 .forEach(producer::produce);
+    }
+
+    static List<String> getStructDefNameExpressions(MethodInfo methodInfo) {
+        return methodInfo.annotations(LH_TYPE).stream()
+                .map(annotation -> annotation.value("structDefName"))
+                .filter(value -> value != null && "structDefName".equals(value.name()))
+                .map(value -> value.asString())
+                .filter(value -> !value.isBlank())
+                .distinct()
+                .sorted()
+                .toList();
     }
 
     @BuildStep

--- a/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
+++ b/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
@@ -37,6 +37,8 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 class LHServiceProcessor {
 
@@ -58,15 +60,13 @@ class LHServiceProcessor {
                 .forEach(producer::produce);
     }
 
-    private static List<String> getStructDefNameTemplates(MethodInfo methodInfo) {
+    private static Set<String> getStructDefNameTemplates(MethodInfo methodInfo) {
         return methodInfo.annotations(LHType.class).stream()
                 .map(annotation -> annotation.value("structDefName"))
                 .filter(value -> value != null && "structDefName".equals(value.name()))
                 .map(value -> value.asString())
                 .filter(value -> !value.isBlank())
-                .distinct()
-                .sorted()
-                .toList();
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     @BuildStep

--- a/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
+++ b/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
@@ -58,7 +58,7 @@ class LHServiceProcessor {
                 .forEach(producer::produce);
     }
 
-    static List<String> getStructDefNameTemplates(MethodInfo methodInfo) {
+    private static List<String> getStructDefNameTemplates(MethodInfo methodInfo) {
         return methodInfo.annotations(LHType.class).stream()
                 .map(annotation -> annotation.value("structDefName"))
                 .filter(value -> value != null && "structDefName".equals(value.name()))

--- a/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
+++ b/extensions/littlehorse-quarkus/deployment/src/main/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessor.java
@@ -40,8 +40,6 @@ import java.util.List;
 
 class LHServiceProcessor {
 
-    private static final DotName LH_TYPE = DotName.createSimple(LHType.class);
-
     @BuildStep
     void scanLHTaskMethod(
             BuildProducer<LHTaskMethodBuildItem> producer,
@@ -61,7 +59,7 @@ class LHServiceProcessor {
     }
 
     static List<String> getStructDefNameTemplates(MethodInfo methodInfo) {
-        return methodInfo.annotations(LH_TYPE).stream()
+        return methodInfo.annotations(LHType.class).stream()
                 .map(annotation -> annotation.value("structDefName"))
                 .filter(value -> value != null && "structDefName".equals(value.name()))
                 .map(value -> value.asString())

--- a/extensions/littlehorse-quarkus/deployment/src/test/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessorTest.java
+++ b/extensions/littlehorse-quarkus/deployment/src/test/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessorTest.java
@@ -21,13 +21,13 @@ class LHServiceProcessorTest {
     @Test
     void shouldCollectInputAndOutputStructDefNameTemplates() throws IOException {
         assertThat(scanTask("transform").getStructDefNameTemplates())
-                .containsExactly("${raw.input.struct.name}", "${raw.output.struct.name}");
+                .containsExactlyInAnyOrder("${raw.input.struct.name}", "${raw.output.struct.name}");
     }
 
     @Test
     void shouldDeduplicateStructDefNameTemplatesDeterministically() throws IOException {
         assertThat(scanTask("reuse").getStructDefNameTemplates())
-                .containsExactly("${shared.struct.name}");
+                .containsExactlyInAnyOrder("${shared.struct.name}");
     }
 
     private static LHTaskMethodRecordable scanTask(String taskName) throws IOException {

--- a/extensions/littlehorse-quarkus/deployment/src/test/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessorTest.java
+++ b/extensions/littlehorse-quarkus/deployment/src/test/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessorTest.java
@@ -2,37 +2,45 @@ package io.littlehorse.quarkus.deployment.processor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.littlehorse.quarkus.deployment.item.LHTaskMethodBuildItem;
+import io.littlehorse.quarkus.runtime.recordable.LHTaskMethodRecordable;
 import io.littlehorse.sdk.common.proto.InlineStruct;
 import io.littlehorse.sdk.worker.LHTaskMethod;
 import io.littlehorse.sdk.worker.LHType;
+import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 
 import org.jboss.jandex.Index;
-import org.jboss.jandex.MethodInfo;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Set;
 
 class LHServiceProcessorTest {
 
     @Test
     void shouldCollectInputAndOutputStructDefNameTemplates() throws IOException {
-        MethodInfo method = methodInfo("transform");
-
-        assertThat(LHServiceProcessor.getStructDefNameTemplates(method))
+        assertThat(scanTask("transform").getStructDefNameTemplates())
                 .containsExactly("${raw.input.struct.name}", "${raw.output.struct.name}");
     }
 
     @Test
     void shouldDeduplicateStructDefNameTemplatesDeterministically() throws IOException {
-        MethodInfo method = methodInfo("reuse");
-
-        assertThat(LHServiceProcessor.getStructDefNameTemplates(method))
+        assertThat(scanTask("reuse").getStructDefNameTemplates())
                 .containsExactly("${shared.struct.name}");
     }
 
-    private static MethodInfo methodInfo(String methodName) throws IOException {
-        return Index.singleClass(RawInlineStructTask.class).methods().stream()
-                .filter(method -> method.name().equals(methodName))
+    private static LHTaskMethodRecordable scanTask(String taskName) throws IOException {
+        Index index = Index.of(RawInlineStructTask.class);
+        BeanArchiveIndexBuildItem indexBuildItem =
+                new BeanArchiveIndexBuildItem(index, index, Set.of());
+        ArrayList<LHTaskMethodBuildItem> taskMethods = new ArrayList<>();
+
+        new LHServiceProcessor().scanLHTaskMethod(taskMethods::add, indexBuildItem);
+
+        return taskMethods.stream()
+                .map(LHTaskMethodBuildItem::toRecordable)
+                .filter(recordable -> recordable.getName().equals(taskName))
                 .findFirst()
                 .orElseThrow();
     }

--- a/extensions/littlehorse-quarkus/deployment/src/test/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessorTest.java
+++ b/extensions/littlehorse-quarkus/deployment/src/test/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessorTest.java
@@ -15,20 +15,19 @@ import java.io.IOException;
 class LHServiceProcessorTest {
 
     @Test
-    void shouldCollectInputAndOutputStructDefNameExpressions() throws IOException {
+    void shouldCollectInputAndOutputStructDefNameTemplates() throws IOException {
         MethodInfo method = methodInfo("transform");
 
-        assertThat(LHServiceProcessor.getStructDefNameExpressions(method))
-                .containsExactly(
-                        "${raw.input.struct.name}", "${raw.output.struct.name:default-response}");
+        assertThat(LHServiceProcessor.getStructDefNameTemplates(method))
+                .containsExactly("${raw.input.struct.name}", "${raw.output.struct.name}");
     }
 
     @Test
-    void shouldDeduplicateStructDefNameExpressionsDeterministically() throws IOException {
+    void shouldDeduplicateStructDefNameTemplatesDeterministically() throws IOException {
         MethodInfo method = methodInfo("reuse");
 
-        assertThat(LHServiceProcessor.getStructDefNameExpressions(method))
-                .containsExactly("${shared.struct.name:shared}");
+        assertThat(LHServiceProcessor.getStructDefNameTemplates(method))
+                .containsExactly("${shared.struct.name}");
     }
 
     private static MethodInfo methodInfo(String methodName) throws IOException {
@@ -41,16 +40,15 @@ class LHServiceProcessorTest {
     static class RawInlineStructTask {
 
         @LHTaskMethod("transform")
-        @LHType(structDefName = "${raw.output.struct.name:default-response}")
+        @LHType(structDefName = "${raw.output.struct.name}")
         InlineStruct transform(
                 @LHType(structDefName = "${raw.input.struct.name}") InlineStruct input) {
             return input;
         }
 
         @LHTaskMethod("reuse")
-        @LHType(structDefName = "${shared.struct.name:shared}")
-        InlineStruct reuse(
-                @LHType(structDefName = "${shared.struct.name:shared}") InlineStruct input) {
+        @LHType(structDefName = "${shared.struct.name}")
+        InlineStruct reuse(@LHType(structDefName = "${shared.struct.name}") InlineStruct input) {
             return input;
         }
     }

--- a/extensions/littlehorse-quarkus/deployment/src/test/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessorTest.java
+++ b/extensions/littlehorse-quarkus/deployment/src/test/java/io/littlehorse/quarkus/deployment/processor/LHServiceProcessorTest.java
@@ -1,0 +1,57 @@
+package io.littlehorse.quarkus.deployment.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.littlehorse.sdk.common.proto.InlineStruct;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+import io.littlehorse.sdk.worker.LHType;
+
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+class LHServiceProcessorTest {
+
+    @Test
+    void shouldCollectInputAndOutputStructDefNameExpressions() throws IOException {
+        MethodInfo method = methodInfo("transform");
+
+        assertThat(LHServiceProcessor.getStructDefNameExpressions(method))
+                .containsExactly(
+                        "${raw.input.struct.name}", "${raw.output.struct.name:default-response}");
+    }
+
+    @Test
+    void shouldDeduplicateStructDefNameExpressionsDeterministically() throws IOException {
+        MethodInfo method = methodInfo("reuse");
+
+        assertThat(LHServiceProcessor.getStructDefNameExpressions(method))
+                .containsExactly("${shared.struct.name:shared}");
+    }
+
+    private static MethodInfo methodInfo(String methodName) throws IOException {
+        return Index.singleClass(RawInlineStructTask.class).methods().stream()
+                .filter(method -> method.name().equals(methodName))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    static class RawInlineStructTask {
+
+        @LHTaskMethod("transform")
+        @LHType(structDefName = "${raw.output.struct.name:default-response}")
+        InlineStruct transform(
+                @LHType(structDefName = "${raw.input.struct.name}") InlineStruct input) {
+            return input;
+        }
+
+        @LHTaskMethod("reuse")
+        @LHType(structDefName = "${shared.struct.name:shared}")
+        InlineStruct reuse(
+                @LHType(structDefName = "${shared.struct.name:shared}") InlineStruct input) {
+            return input;
+        }
+    }
+}

--- a/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/LHRecorder.java
+++ b/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/LHRecorder.java
@@ -64,7 +64,7 @@ public class LHRecorder {
                 });
     }
 
-    static Map<String, String> computeTaskPlaceholderValues(
+    private static Map<String, String> computeTaskPlaceholderValues(
             ConfigEvaluator configEvaluator,
             Map<String, String> structPlaceholderValues,
             LHTaskMethodRecordable recordable) {

--- a/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/LHRecorder.java
+++ b/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/LHRecorder.java
@@ -30,14 +30,17 @@ import jakarta.enterprise.inject.spi.CDI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Recorder
 public class LHRecorder {
     private static final Logger log = LoggerFactory.getLogger(LHRecorder.class);
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{(.*?)}");
     private final RuntimeValue<LHRuntimeConfig> runtimeConfig;
 
     public LHRecorder(RuntimeValue<LHRuntimeConfig> runtimeConfig) {
@@ -57,12 +60,69 @@ public class LHRecorder {
         taskMethodRecordables.stream()
                 .filter(recordable -> doesBeanExist(recordable.getBeanClass()))
                 .forEach(recordable -> {
-                    Map<String, String> placeholderValues = new HashMap<>(structPlaceholderValues);
-                    placeholderValues.putAll(
-                            configEvaluator.expand(recordable.getName()).getMembers());
+                    Map<String, String> placeholderValues = computeTaskPlaceholderValues(
+                            configEvaluator, structPlaceholderValues, recordable);
                     recordable.setPlaceholderValues(placeholderValues);
                     registerAndStartTask(recordable, shutdownContext);
                 });
+    }
+
+    static Map<String, String> computeTaskPlaceholderValues(
+            ConfigEvaluator configEvaluator,
+            Map<String, String> structPlaceholderValues,
+            LHTaskMethodRecordable recordable) {
+        Map<String, String> placeholderValues = new LinkedHashMap<>();
+        mergePlaceholderValues(placeholderValues, structPlaceholderValues);
+        mergeExpressionPlaceholderValues(placeholderValues, configEvaluator, recordable.getName());
+        recordable.getStructDefNameExpressions().stream()
+                .sorted()
+                .forEach(expression -> mergeExpressionPlaceholderValues(
+                        placeholderValues, configEvaluator, expression));
+        return Map.copyOf(placeholderValues);
+    }
+
+    private static void mergeExpressionPlaceholderValues(
+            Map<String, String> placeholderValues,
+            ConfigEvaluator configEvaluator,
+            String expression) {
+        ConfigEvaluator.ConfigExpression expanded = configEvaluator.expand(expression);
+        mergePlaceholderValues(placeholderValues, expanded.getMembers());
+
+        // The LittleHorse SDK treats the complete contents of `${...}` as the placeholder key.
+        // ConfigEvaluator instead reports the configuration key without its default, so add an
+        // alias that lets expressions such as `${customer.name:customer}` reach the SDK intact.
+        Matcher matcher = PLACEHOLDER_PATTERN.matcher(expression);
+        while (matcher.find()) {
+            String sdkPlaceholderKey = matcher.group(1);
+            int defaultSeparator = sdkPlaceholderKey.indexOf(':');
+            if (defaultSeparator < 0) {
+                continue;
+            }
+
+            String configKey = sdkPlaceholderKey.substring(0, defaultSeparator);
+            String value = expanded.getMembers().get(configKey);
+            if (value != null) {
+                mergePlaceholderValue(placeholderValues, sdkPlaceholderKey, value);
+            }
+        }
+    }
+
+    private static void mergePlaceholderValues(
+            Map<String, String> placeholderValues, Map<String, String> additions) {
+        additions.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry ->
+                        mergePlaceholderValue(placeholderValues, entry.getKey(), entry.getValue()));
+    }
+
+    private static void mergePlaceholderValue(
+            Map<String, String> placeholderValues, String key, String value) {
+        String existingValue = placeholderValues.putIfAbsent(key, value);
+        if (existingValue != null && !existingValue.equals(value)) {
+            throw new IllegalStateException(
+                    "Conflicting values for configuration placeholder '%s': '%s' and '%s'"
+                            .formatted(key, existingValue, value));
+        }
     }
 
     private void registerAndStartTask(
@@ -189,10 +249,13 @@ public class LHRecorder {
     private Map<String, String> computeStructPlaceholderValues(
             List<LHStructDefRecordable> structDefRecordables) {
         ConfigEvaluator configEvaluator = getBean(ConfigEvaluator.class);
-        Map<String, String> placeholderValues = new HashMap<>();
-        structDefRecordables.forEach(recordable -> placeholderValues.putAll(
-                configEvaluator.expand(recordable.getName()).getMembers()));
-        return placeholderValues;
+        Map<String, String> placeholderValues = new LinkedHashMap<>();
+        structDefRecordables.stream()
+                .map(LHStructDefRecordable::getName)
+                .sorted()
+                .forEach(expression -> mergeExpressionPlaceholderValues(
+                        placeholderValues, configEvaluator, expression));
+        return Map.copyOf(placeholderValues);
     }
 
     private void registerLHStructDef(

--- a/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/LHRecorder.java
+++ b/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/LHRecorder.java
@@ -34,13 +34,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Recorder
 public class LHRecorder {
     private static final Logger log = LoggerFactory.getLogger(LHRecorder.class);
-    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{(.*?)}");
     private final RuntimeValue<LHRuntimeConfig> runtimeConfig;
 
     public LHRecorder(RuntimeValue<LHRuntimeConfig> runtimeConfig) {
@@ -73,38 +70,20 @@ public class LHRecorder {
             LHTaskMethodRecordable recordable) {
         Map<String, String> placeholderValues = new LinkedHashMap<>();
         mergePlaceholderValues(placeholderValues, structPlaceholderValues);
-        mergeExpressionPlaceholderValues(placeholderValues, configEvaluator, recordable.getName());
-        recordable.getStructDefNameExpressions().stream()
+        mergeTemplatePlaceholderValues(placeholderValues, configEvaluator, recordable.getName());
+        recordable.getStructDefNameTemplates().stream()
                 .sorted()
-                .forEach(expression -> mergeExpressionPlaceholderValues(
-                        placeholderValues, configEvaluator, expression));
+                .forEach(template -> mergeTemplatePlaceholderValues(
+                        placeholderValues, configEvaluator, template));
         return Map.copyOf(placeholderValues);
     }
 
-    private static void mergeExpressionPlaceholderValues(
+    private static void mergeTemplatePlaceholderValues(
             Map<String, String> placeholderValues,
             ConfigEvaluator configEvaluator,
-            String expression) {
-        ConfigEvaluator.ConfigExpression expanded = configEvaluator.expand(expression);
+            String template) {
+        ConfigEvaluator.ConfigExpression expanded = configEvaluator.expand(template);
         mergePlaceholderValues(placeholderValues, expanded.getMembers());
-
-        // The LittleHorse SDK treats the complete contents of `${...}` as the placeholder key.
-        // ConfigEvaluator instead reports the configuration key without its default, so add an
-        // alias that lets expressions such as `${customer.name:customer}` reach the SDK intact.
-        Matcher matcher = PLACEHOLDER_PATTERN.matcher(expression);
-        while (matcher.find()) {
-            String sdkPlaceholderKey = matcher.group(1);
-            int defaultSeparator = sdkPlaceholderKey.indexOf(':');
-            if (defaultSeparator < 0) {
-                continue;
-            }
-
-            String configKey = sdkPlaceholderKey.substring(0, defaultSeparator);
-            String value = expanded.getMembers().get(configKey);
-            if (value != null) {
-                mergePlaceholderValue(placeholderValues, sdkPlaceholderKey, value);
-            }
-        }
     }
 
     private static void mergePlaceholderValues(
@@ -253,8 +232,8 @@ public class LHRecorder {
         structDefRecordables.stream()
                 .map(LHStructDefRecordable::getName)
                 .sorted()
-                .forEach(expression -> mergeExpressionPlaceholderValues(
-                        placeholderValues, configEvaluator, expression));
+                .forEach(template -> mergeTemplatePlaceholderValues(
+                        placeholderValues, configEvaluator, template));
         return Map.copyOf(placeholderValues);
     }
 

--- a/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/recordable/LHTaskMethodRecordable.java
+++ b/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/recordable/LHTaskMethodRecordable.java
@@ -2,17 +2,33 @@ package io.littlehorse.quarkus.runtime.recordable;
 
 import io.quarkus.runtime.annotations.RecordableConstructor;
 
+import java.util.List;
+
 public class LHTaskMethodRecordable extends LHRecordable {
 
     private final String description;
+    private final List<String> structDefNameExpressions;
+
+    public LHTaskMethodRecordable(Class<?> beanClass, String name, String description) {
+        this(beanClass, name, description, List.of());
+    }
 
     @RecordableConstructor
-    public LHTaskMethodRecordable(Class<?> beanClass, String name, String description) {
+    public LHTaskMethodRecordable(
+            Class<?> beanClass,
+            String name,
+            String description,
+            List<String> structDefNameExpressions) {
         super(beanClass, name);
         this.description = description;
+        this.structDefNameExpressions = List.copyOf(structDefNameExpressions);
     }
 
     public String getDescription() {
         return description;
+    }
+
+    public List<String> getStructDefNameExpressions() {
+        return structDefNameExpressions;
     }
 }

--- a/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/recordable/LHTaskMethodRecordable.java
+++ b/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/recordable/LHTaskMethodRecordable.java
@@ -2,15 +2,15 @@ package io.littlehorse.quarkus.runtime.recordable;
 
 import io.quarkus.runtime.annotations.RecordableConstructor;
 
-import java.util.List;
+import java.util.Set;
 
 public class LHTaskMethodRecordable extends LHRecordable {
 
     private final String description;
-    private final List<String> structDefNameTemplates;
+    private final Set<String> structDefNameTemplates;
 
     public LHTaskMethodRecordable(Class<?> beanClass, String name, String description) {
-        this(beanClass, name, description, List.of());
+        this(beanClass, name, description, Set.of());
     }
 
     @RecordableConstructor
@@ -18,17 +18,17 @@ public class LHTaskMethodRecordable extends LHRecordable {
             Class<?> beanClass,
             String name,
             String description,
-            List<String> structDefNameTemplates) {
+            Set<String> structDefNameTemplates) {
         super(beanClass, name);
         this.description = description;
-        this.structDefNameTemplates = List.copyOf(structDefNameTemplates);
+        this.structDefNameTemplates = Set.copyOf(structDefNameTemplates);
     }
 
     public String getDescription() {
         return description;
     }
 
-    public List<String> getStructDefNameTemplates() {
+    public Set<String> getStructDefNameTemplates() {
         return structDefNameTemplates;
     }
 }

--- a/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/recordable/LHTaskMethodRecordable.java
+++ b/extensions/littlehorse-quarkus/runtime/src/main/java/io/littlehorse/quarkus/runtime/recordable/LHTaskMethodRecordable.java
@@ -7,7 +7,7 @@ import java.util.List;
 public class LHTaskMethodRecordable extends LHRecordable {
 
     private final String description;
-    private final List<String> structDefNameExpressions;
+    private final List<String> structDefNameTemplates;
 
     public LHTaskMethodRecordable(Class<?> beanClass, String name, String description) {
         this(beanClass, name, description, List.of());
@@ -18,17 +18,17 @@ public class LHTaskMethodRecordable extends LHRecordable {
             Class<?> beanClass,
             String name,
             String description,
-            List<String> structDefNameExpressions) {
+            List<String> structDefNameTemplates) {
         super(beanClass, name);
         this.description = description;
-        this.structDefNameExpressions = List.copyOf(structDefNameExpressions);
+        this.structDefNameTemplates = List.copyOf(structDefNameTemplates);
     }
 
     public String getDescription() {
         return description;
     }
 
-    public List<String> getStructDefNameExpressions() {
-        return structDefNameExpressions;
+    public List<String> getStructDefNameTemplates() {
+        return structDefNameTemplates;
     }
 }

--- a/extensions/littlehorse-quarkus/runtime/src/test/java/io/littlehorse/quarkus/runtime/LHRecorderTaskPlaceholderTest.java
+++ b/extensions/littlehorse-quarkus/runtime/src/test/java/io/littlehorse/quarkus/runtime/LHRecorderTaskPlaceholderTest.java
@@ -1,0 +1,95 @@
+package io.littlehorse.quarkus.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.littlehorse.quarkus.config.ConfigEvaluator;
+import io.littlehorse.quarkus.runtime.recordable.LHTaskMethodRecordable;
+import io.littlehorse.sdk.worker.internal.util.PlaceholderUtil;
+import io.smallrye.config.SmallRyeConfig;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+class LHRecorderTaskPlaceholderTest {
+
+    private ConfigEvaluator configEvaluator;
+
+    @BeforeEach
+    void setUp() {
+        configEvaluator =
+                new ConfigEvaluator(ConfigProvider.getConfig().unwrap(SmallRyeConfig.class));
+    }
+
+    @Test
+    void shouldResolveRawInlineStructInputAndOutputPlaceholdersWithoutLocalStructDefs() {
+        LHTaskMethodRecordable recordable = recordable(
+                "${raw.task.name:raw-task}",
+                "${raw.input.struct.name}",
+                "${raw.output.struct.name:default-response}");
+
+        Map<String, String> values =
+                LHRecorder.computeTaskPlaceholderValues(configEvaluator, Map.of(), recordable);
+
+        assertThat(values)
+                .containsEntry("raw.task.name", "raw-task")
+                .containsEntry("raw.task.name:raw-task", "raw-task")
+                .containsEntry("raw.input.struct.name", "configured-request")
+                .containsEntry("raw.output.struct.name", "default-response")
+                .containsEntry("raw.output.struct.name:default-response", "default-response");
+        assertThat(PlaceholderUtil.replacePlaceholders("${raw.input.struct.name}", values))
+                .isEqualTo("configured-request");
+        assertThat(PlaceholderUtil.replacePlaceholders(
+                        "${raw.output.struct.name:default-response}", values))
+                .isEqualTo("default-response");
+    }
+
+    @Test
+    void shouldFailWithMissingLHTypeConfigurationKey() {
+        LHTaskMethodRecordable recordable =
+                recordable("raw-task", "${missing.raw.input.struct.name}");
+
+        assertThatThrownBy(() -> LHRecorder.computeTaskPlaceholderValues(
+                        configEvaluator, Map.of(), recordable))
+                .isInstanceOf(java.util.NoSuchElementException.class)
+                .hasMessageContaining("missing.raw.input.struct.name");
+    }
+
+    @Test
+    void shouldPreservePlaceholderValuesFromConfiguredStructDefs() {
+        LHTaskMethodRecordable recordable = recordable("raw-task", "${my.config.test}");
+
+        Map<String, String> values = LHRecorder.computeTaskPlaceholderValues(
+                configEvaluator,
+                Map.of("my.config.test", "this-is-a-test", "nested.struct.name", "nested"),
+                recordable);
+
+        assertThat(values)
+                .containsEntry("my.config.test", "this-is-a-test")
+                .containsEntry("nested.struct.name", "nested");
+    }
+
+    @Test
+    void shouldFailDeterministicallyForConflictingDuplicatePlaceholderValues() {
+        LHTaskMethodRecordable recordable = recordable(
+                "raw-task", "${duplicate.struct.name:first}", "${duplicate.struct.name:second}");
+
+        assertThatThrownBy(() -> LHRecorder.computeTaskPlaceholderValues(
+                        configEvaluator, Map.of(), recordable))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Conflicting values for configuration placeholder "
+                        + "'duplicate.struct.name': 'first' and 'second'");
+    }
+
+    private static LHTaskMethodRecordable recordable(
+            String taskName, String... structDefNameExpressions) {
+        return new LHTaskMethodRecordable(
+                RawInlineStructTask.class, taskName, null, List.of(structDefNameExpressions));
+    }
+
+    static class RawInlineStructTask {}
+}

--- a/extensions/littlehorse-quarkus/runtime/src/test/java/io/littlehorse/quarkus/runtime/LHRecorderTest.java
+++ b/extensions/littlehorse-quarkus/runtime/src/test/java/io/littlehorse/quarkus/runtime/LHRecorderTest.java
@@ -2,16 +2,35 @@ package io.littlehorse.quarkus.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 import io.littlehorse.quarkus.config.ConfigEvaluator;
+import io.littlehorse.quarkus.config.LHRuntimeConfig;
+import io.littlehorse.quarkus.runtime.recordable.LHStructDefRecordable;
 import io.littlehorse.quarkus.runtime.recordable.LHTaskMethodRecordable;
+import io.littlehorse.sdk.common.config.LHConfig;
+import io.littlehorse.sdk.worker.LHTaskWorker;
 import io.littlehorse.sdk.worker.internal.util.PlaceholderUtil;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.ShutdownContext;
 import io.smallrye.config.SmallRyeConfig;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -30,8 +49,7 @@ class LHRecorderTest {
         LHTaskMethodRecordable recordable = recordable(
                 "${raw.task.name}", "${raw.input.struct.name}", "${raw.output.struct.name}");
 
-        Map<String, String> values =
-                LHRecorder.computeTaskPlaceholderValues(configEvaluator, Map.of(), recordable);
+        Map<String, String> values = startTask(recordable, List.of());
 
         assertThat(values)
                 .containsEntry("raw.task.name", "raw-task")
@@ -50,8 +68,7 @@ class LHRecorderTest {
         LHTaskMethodRecordable recordable =
                 recordable("raw-task", "${missing.raw.input.struct.name}");
 
-        assertThatThrownBy(() -> LHRecorder.computeTaskPlaceholderValues(
-                        configEvaluator, Map.of(), recordable))
+        assertThatThrownBy(() -> startTask(recordable, List.of()))
                 .isInstanceOf(java.util.NoSuchElementException.class)
                 .hasMessageContaining("missing.raw.input.struct.name");
     }
@@ -59,11 +76,10 @@ class LHRecorderTest {
     @Test
     void shouldPreservePlaceholderValuesFromConfiguredStructDefs() {
         LHTaskMethodRecordable recordable = recordable("raw-task", "${my.config.test}");
+        List<LHStructDefRecordable> structDefs =
+                List.of(structDef("${my.config.test}"), structDef("${nested.struct.name}"));
 
-        Map<String, String> values = LHRecorder.computeTaskPlaceholderValues(
-                configEvaluator,
-                Map.of("my.config.test", "this-is-a-test", "nested.struct.name", "nested"),
-                recordable);
+        Map<String, String> values = startTask(recordable, structDefs);
 
         assertThat(values)
                 .containsEntry("my.config.test", "this-is-a-test")
@@ -71,22 +87,61 @@ class LHRecorderTest {
     }
 
     @Test
-    void shouldFailDeterministicallyForConflictingPlaceholderValues() {
-        LHTaskMethodRecordable recordable = recordable("raw-task", "${my.config.test}");
+    void shouldHandleTheSamePlaceholderFromMultipleLocationsDeterministically() {
+        LHTaskMethodRecordable recordable =
+                recordable("${my.config.test}", "${my.config.test}", "${my.config.test}");
 
-        assertThatThrownBy(() -> LHRecorder.computeTaskPlaceholderValues(
-                        configEvaluator,
-                        Map.of("my.config.test", "configured-by-struct"),
-                        recordable))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Conflicting values for configuration placeholder "
-                        + "'my.config.test': 'configured-by-struct' and 'this-is-a-test'");
+        assertThat(startTask(recordable, List.of(structDef("${my.config.test}"))))
+                .containsExactly(Map.entry("my.config.test", "this-is-a-test"));
     }
 
     private static LHTaskMethodRecordable recordable(
             String taskName, String... structDefNameTemplates) {
         return new LHTaskMethodRecordable(
                 RawInlineStructTask.class, taskName, null, List.of(structDefNameTemplates));
+    }
+
+    private static LHStructDefRecordable structDef(String name) {
+        return new LHStructDefRecordable(RawInlineStructTask.class, name, null);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Map<String, String> startTask(
+            LHTaskMethodRecordable recordable, List<LHStructDefRecordable> structDefs) {
+        LHRuntimeConfig runtimeConfig = mock(LHRuntimeConfig.class);
+        when(runtimeConfig.specificTaskConfigs()).thenReturn(Map.of());
+        when(runtimeConfig.tasksRegisterEnabled()).thenReturn(false);
+        when(runtimeConfig.tasksStartEnabled()).thenReturn(false);
+
+        Map<Class<?>, Object> beans = new LinkedHashMap<>();
+        beans.put(ConfigEvaluator.class, configEvaluator);
+        beans.put(LHConfig.class, mock(LHConfig.class));
+        beans.put(LHTaskStatusesContainer.class, mock(LHTaskStatusesContainer.class));
+        beans.put(RawInlineStructTask.class, new RawInlineStructTask());
+
+        CDI<Object> cdi = mock(CDI.class);
+        when(cdi.select(any(Class.class), any(Annotation[].class))).thenAnswer(invocation -> {
+            Class<?> beanClass = invocation.getArgument(0);
+            Instance<Object> instance = mock(Instance.class);
+            when(instance.isResolvable()).thenReturn(beans.containsKey(beanClass));
+            when(instance.get()).thenReturn(beans.get(beanClass));
+            return instance;
+        });
+
+        List<List<?>> constructorArguments = new ArrayList<>();
+        try (MockedStatic<CDI> mockedCdi = mockStatic(CDI.class);
+                MockedConstruction<LHTaskWorker> workers = mockConstruction(
+                        LHTaskWorker.class,
+                        (worker, context) -> constructorArguments.add(context.arguments()))) {
+            mockedCdi.when(CDI::current).thenReturn(cdi);
+
+            LHRecorder recorder = new LHRecorder(new RuntimeValue<>(runtimeConfig));
+            recorder.registerAndStartTasks(
+                    List.of(recordable), structDefs, mock(ShutdownContext.class));
+
+            assertThat(workers.constructed()).hasSize(1);
+            return (Map<String, String>) constructorArguments.get(0).get(3);
+        }
     }
 
     static class RawInlineStructTask {}

--- a/extensions/littlehorse-quarkus/runtime/src/test/java/io/littlehorse/quarkus/runtime/LHRecorderTest.java
+++ b/extensions/littlehorse-quarkus/runtime/src/test/java/io/littlehorse/quarkus/runtime/LHRecorderTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
-class LHRecorderTaskPlaceholderTest {
+class LHRecorderTest {
 
     private ConfigEvaluator configEvaluator;
 
@@ -28,24 +28,21 @@ class LHRecorderTaskPlaceholderTest {
     @Test
     void shouldResolveRawInlineStructInputAndOutputPlaceholdersWithoutLocalStructDefs() {
         LHTaskMethodRecordable recordable = recordable(
-                "${raw.task.name:raw-task}",
-                "${raw.input.struct.name}",
-                "${raw.output.struct.name:default-response}");
+                "${raw.task.name}", "${raw.input.struct.name}", "${raw.output.struct.name}");
 
         Map<String, String> values =
                 LHRecorder.computeTaskPlaceholderValues(configEvaluator, Map.of(), recordable);
 
         assertThat(values)
                 .containsEntry("raw.task.name", "raw-task")
-                .containsEntry("raw.task.name:raw-task", "raw-task")
                 .containsEntry("raw.input.struct.name", "configured-request")
-                .containsEntry("raw.output.struct.name", "default-response")
-                .containsEntry("raw.output.struct.name:default-response", "default-response");
+                .containsEntry("raw.output.struct.name", "configured-response");
+        assertThat(PlaceholderUtil.replacePlaceholders("${raw.task.name}", values))
+                .isEqualTo("raw-task");
         assertThat(PlaceholderUtil.replacePlaceholders("${raw.input.struct.name}", values))
                 .isEqualTo("configured-request");
-        assertThat(PlaceholderUtil.replacePlaceholders(
-                        "${raw.output.struct.name:default-response}", values))
-                .isEqualTo("default-response");
+        assertThat(PlaceholderUtil.replacePlaceholders("${raw.output.struct.name}", values))
+                .isEqualTo("configured-response");
     }
 
     @Test
@@ -74,21 +71,22 @@ class LHRecorderTaskPlaceholderTest {
     }
 
     @Test
-    void shouldFailDeterministicallyForConflictingDuplicatePlaceholderValues() {
-        LHTaskMethodRecordable recordable = recordable(
-                "raw-task", "${duplicate.struct.name:first}", "${duplicate.struct.name:second}");
+    void shouldFailDeterministicallyForConflictingPlaceholderValues() {
+        LHTaskMethodRecordable recordable = recordable("raw-task", "${my.config.test}");
 
         assertThatThrownBy(() -> LHRecorder.computeTaskPlaceholderValues(
-                        configEvaluator, Map.of(), recordable))
+                        configEvaluator,
+                        Map.of("my.config.test", "configured-by-struct"),
+                        recordable))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Conflicting values for configuration placeholder "
-                        + "'duplicate.struct.name': 'first' and 'second'");
+                        + "'my.config.test': 'configured-by-struct' and 'this-is-a-test'");
     }
 
     private static LHTaskMethodRecordable recordable(
-            String taskName, String... structDefNameExpressions) {
+            String taskName, String... structDefNameTemplates) {
         return new LHTaskMethodRecordable(
-                RawInlineStructTask.class, taskName, null, List.of(structDefNameExpressions));
+                RawInlineStructTask.class, taskName, null, List.of(structDefNameTemplates));
     }
 
     static class RawInlineStructTask {}

--- a/extensions/littlehorse-quarkus/runtime/src/test/java/io/littlehorse/quarkus/runtime/LHRecorderTest.java
+++ b/extensions/littlehorse-quarkus/runtime/src/test/java/io/littlehorse/quarkus/runtime/LHRecorderTest.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 class LHRecorderTest {
 
@@ -88,8 +89,7 @@ class LHRecorderTest {
 
     @Test
     void shouldHandleTheSamePlaceholderFromMultipleLocationsDeterministically() {
-        LHTaskMethodRecordable recordable =
-                recordable("${my.config.test}", "${my.config.test}", "${my.config.test}");
+        LHTaskMethodRecordable recordable = recordable("${my.config.test}", "${my.config.test}");
 
         assertThat(startTask(recordable, List.of(structDef("${my.config.test}"))))
                 .containsExactly(Map.entry("my.config.test", "this-is-a-test"));
@@ -98,7 +98,7 @@ class LHRecorderTest {
     private static LHTaskMethodRecordable recordable(
             String taskName, String... structDefNameTemplates) {
         return new LHTaskMethodRecordable(
-                RawInlineStructTask.class, taskName, null, List.of(structDefNameTemplates));
+                RawInlineStructTask.class, taskName, null, Set.of(structDefNameTemplates));
     }
 
     private static LHStructDefRecordable structDef(String name) {

--- a/extensions/littlehorse-quarkus/runtime/src/test/resources/application.properties
+++ b/extensions/littlehorse-quarkus/runtime/src/test/resources/application.properties
@@ -2,3 +2,5 @@ my.config.test=this-is-a-test
 my.second.config.test=this-is-a-second-test
 my.compose.config=my.config.test
 raw.input.struct.name=configured-request
+raw.output.struct.name=configured-response
+raw.task.name=raw-task

--- a/extensions/littlehorse-quarkus/runtime/src/test/resources/application.properties
+++ b/extensions/littlehorse-quarkus/runtime/src/test/resources/application.properties
@@ -4,3 +4,4 @@ my.compose.config=my.config.test
 raw.input.struct.name=configured-request
 raw.output.struct.name=configured-response
 raw.task.name=raw-task
+nested.struct.name=nested

--- a/extensions/littlehorse-quarkus/runtime/src/test/resources/application.properties
+++ b/extensions/littlehorse-quarkus/runtime/src/test/resources/application.properties
@@ -1,3 +1,4 @@
 my.config.test=this-is-a-test
 my.second.config.test=this-is-a-second-test
 my.compose.config=my.config.test
+raw.input.struct.name=configured-request

--- a/extensions/littlehorse-saddle-bag/deployment/src/main/java/io/littlehorse/quarkus/saddle/deployment/model/SaddleBag.java
+++ b/extensions/littlehorse-saddle-bag/deployment/src/main/java/io/littlehorse/quarkus/saddle/deployment/model/SaddleBag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Immutable model of a generated saddle bag manifest. All optional fields are omitted from the
@@ -24,7 +25,7 @@ public record SaddleBag(
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record Metadata(
-            List<String> tags,
+            Set<String> tags,
             String licence,
             @JsonProperty("documentation-url") String documentationUrl,
             @JsonProperty("icon-url") String iconUrl,

--- a/extensions/littlehorse-saddle-bag/deployment/src/test/java/io/littlehorse/quarkus/saddle/deployment/processor/LHSaddleBagProcessorTest.java
+++ b/extensions/littlehorse-saddle-bag/deployment/src/test/java/io/littlehorse/quarkus/saddle/deployment/processor/LHSaddleBagProcessorTest.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 class LHSaddleBagProcessorTest {
 
@@ -121,6 +122,14 @@ class LHSaddleBagProcessorTest {
                 .isEqualTo(Type.map(Type.primitive("STR"), Type.primitive("INT")));
         assertThat(saddlebag.tasks().get("produce-array").output().type())
                 .isEqualTo(Type.array(Type.primitive("INT")));
+    }
+
+    @Test
+    void generateSaddlebagDeduplicatesMetadataTags() throws Exception {
+        SaddleBag saddlebag = generateSaddlebag(
+                List.of(), Map.of("quarkus.littlehorse.saddle.bag.metadata.tags", "t1,t2,t1"));
+
+        assertThat(saddlebag.metadata().tags()).containsExactlyInAnyOrder("t1", "t2");
     }
 
     @Test
@@ -390,7 +399,7 @@ class LHSaddleBagProcessorTest {
 
     private SaddleBag sampleSaddlebag() {
         Metadata metadata = new Metadata(
-                List.of("test", "example"),
+                Set.of("test", "example"),
                 "MIT",
                 "https://example.com/docs",
                 null,

--- a/extensions/littlehorse-saddle-bag/runtime/src/main/java/io/littlehorse/quarkus/saddle/config/LHSaddleBagBuildtimeConfig.java
+++ b/extensions/littlehorse-saddle-bag/runtime/src/main/java/io/littlehorse/quarkus/saddle/config/LHSaddleBagBuildtimeConfig.java
@@ -6,7 +6,7 @@ import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 
-import java.util.List;
+import java.util.Set;
 
 @ConfigMapping(prefix = "quarkus.littlehorse")
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
@@ -51,7 +51,7 @@ public interface LHSaddleBagBuildtimeConfig {
             }
 
             interface MetadataConfig {
-                List<String> tags();
+                Set<String> tags();
 
                 String licence();
 

--- a/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/common/ContainersTestResource.java
+++ b/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/common/ContainersTestResource.java
@@ -1,5 +1,6 @@
 package io.littlehorse.common;
 
+import static io.littlehorse.tasks.ExternalInlineStructTask.PROMPT_STRUCT_DEF_NAME;
 import static io.littlehorse.tasks.ExternalInlineStructTask.REQUEST_STRUCT_DEF_NAME;
 import static io.littlehorse.tasks.ExternalInlineStructTask.RESPONSE_STRUCT_DEF_NAME;
 
@@ -9,6 +10,7 @@ import io.littlehorse.sdk.common.proto.InlineStructDef;
 import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
 import io.littlehorse.sdk.common.proto.PutStructDefRequest;
 import io.littlehorse.sdk.common.proto.StructDefCompatibilityType;
+import io.littlehorse.sdk.common.proto.StructDefId;
 import io.littlehorse.sdk.common.proto.StructFieldDef;
 import io.littlehorse.sdk.common.proto.TypeDefinition;
 import io.littlehorse.sdk.common.proto.VariableType;
@@ -48,8 +50,14 @@ public class ContainersTestResource implements QuarkusTestResourceLifecycleManag
 
     private void registerExternalStructDefs() {
         blockingStub.putStructDef(PutStructDefRequest.newBuilder()
+                .setName(PROMPT_STRUCT_DEF_NAME)
+                .setStructDef(InlineStructDef.newBuilder().putFields("text", stringField()))
+                .setAllowedUpdates(StructDefCompatibilityType.NO_SCHEMA_UPDATES)
+                .build());
+        blockingStub.putStructDef(PutStructDefRequest.newBuilder()
                 .setName(REQUEST_STRUCT_DEF_NAME)
-                .setStructDef(InlineStructDef.newBuilder().putFields("prompt", stringField()))
+                .setStructDef(InlineStructDef.newBuilder()
+                        .putFields("prompt", structField(PROMPT_STRUCT_DEF_NAME)))
                 .setAllowedUpdates(StructDefCompatibilityType.NO_SCHEMA_UPDATES)
                 .build());
         blockingStub.putStructDef(PutStructDefRequest.newBuilder()
@@ -62,6 +70,13 @@ public class ContainersTestResource implements QuarkusTestResourceLifecycleManag
     private static StructFieldDef stringField() {
         return StructFieldDef.newBuilder()
                 .setFieldType(TypeDefinition.newBuilder().setPrimitiveType(VariableType.STR))
+                .build();
+    }
+
+    private static StructFieldDef structField(String structDefName) {
+        return StructFieldDef.newBuilder()
+                .setFieldType(TypeDefinition.newBuilder()
+                        .setStructDefId(StructDefId.newBuilder().setName(structDefName)))
                 .build();
     }
 

--- a/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/common/ContainersTestResource.java
+++ b/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/common/ContainersTestResource.java
@@ -1,8 +1,17 @@
 package io.littlehorse.common;
 
+import static io.littlehorse.tasks.ExternalInlineStructTask.REQUEST_STRUCT_DEF_NAME;
+import static io.littlehorse.tasks.ExternalInlineStructTask.RESPONSE_STRUCT_DEF_NAME;
+
 import io.littlehorse.container.LittleHorseCluster;
 import io.littlehorse.sdk.common.config.LHConfig;
+import io.littlehorse.sdk.common.proto.InlineStructDef;
 import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.PutStructDefRequest;
+import io.littlehorse.sdk.common.proto.StructDefCompatibilityType;
+import io.littlehorse.sdk.common.proto.StructFieldDef;
+import io.littlehorse.sdk.common.proto.TypeDefinition;
+import io.littlehorse.sdk.common.proto.VariableType;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager.TestInjector.AnnotatedAndMatchesType;
 
@@ -19,6 +28,7 @@ public class ContainersTestResource implements QuarkusTestResourceLifecycleManag
     private static final Logger log = LoggerFactory.getLogger(ContainersTestResource.class);
 
     private LittleHorseCluster cluster;
+    private LHConfig config;
     private LittleHorseBlockingStub blockingStub;
 
     @Override
@@ -30,11 +40,29 @@ public class ContainersTestResource implements QuarkusTestResourceLifecycleManag
                         "ghcr.io/littlehorse-enterprises/littlehorse/lh-server:" + LH_VERSION)
                 .build();
         cluster.start();
-        blockingStub = LHConfig.newBuilder()
-                .loadFromMap(cluster.getClientConfig())
-                .build()
-                .getBlockingStub();
+        config = LHConfig.newBuilder().loadFromMap(cluster.getClientConfig()).build();
+        blockingStub = config.getBlockingStub();
+        registerExternalStructDefs();
         return cluster.getClientConfig();
+    }
+
+    private void registerExternalStructDefs() {
+        blockingStub.putStructDef(PutStructDefRequest.newBuilder()
+                .setName(REQUEST_STRUCT_DEF_NAME)
+                .setStructDef(InlineStructDef.newBuilder().putFields("prompt", stringField()))
+                .setAllowedUpdates(StructDefCompatibilityType.NO_SCHEMA_UPDATES)
+                .build());
+        blockingStub.putStructDef(PutStructDefRequest.newBuilder()
+                .setName(RESPONSE_STRUCT_DEF_NAME)
+                .setStructDef(InlineStructDef.newBuilder().putFields("response", stringField()))
+                .setAllowedUpdates(StructDefCompatibilityType.NO_SCHEMA_UPDATES)
+                .build());
+    }
+
+    private static StructFieldDef stringField() {
+        return StructFieldDef.newBuilder()
+                .setFieldType(TypeDefinition.newBuilder().setPrimitiveType(VariableType.STR))
+                .build();
     }
 
     @Override
@@ -49,5 +77,7 @@ public class ContainersTestResource implements QuarkusTestResourceLifecycleManag
                 blockingStub,
                 new AnnotatedAndMatchesType(
                         InjectLittleHorseBlockingStub.class, LittleHorseBlockingStub.class));
+        testInjector.injectIntoFields(
+                config, new AnnotatedAndMatchesType(InjectLittleHorseConfig.class, LHConfig.class));
     }
 }

--- a/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/common/InjectLittleHorseConfig.java
+++ b/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/common/InjectLittleHorseConfig.java
@@ -1,0 +1,10 @@
+package io.littlehorse.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InjectLittleHorseConfig {}

--- a/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/ExternalInlineStructPlaceholderTest.java
+++ b/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/ExternalInlineStructPlaceholderTest.java
@@ -1,5 +1,6 @@
 package io.littlehorse.test;
 
+import static io.littlehorse.tasks.ExternalInlineStructTask.PROMPT_STRUCT_DEF_NAME;
 import static io.littlehorse.tasks.ExternalInlineStructTask.REQUEST_STRUCT_DEF_NAME;
 import static io.littlehorse.tasks.ExternalInlineStructTask.REQUEST_VARIABLE;
 import static io.littlehorse.tasks.ExternalInlineStructTask.RESPONSE_STRUCT_DEF_NAME;
@@ -55,8 +56,17 @@ class ExternalInlineStructPlaceholderTest {
 
     @Test
     void shouldRunQuarkusManagedTaskWithExternalConfiguredStructDefs() {
+        StructDef promptStructDef = blockingStub.getStructDef(
+                StructDefId.newBuilder().setName(PROMPT_STRUCT_DEF_NAME).build());
         StructDef requestStructDef = blockingStub.getStructDef(
                 StructDefId.newBuilder().setName(REQUEST_STRUCT_DEF_NAME).build());
+        assertThat(requestStructDef
+                        .getStructDef()
+                        .getFieldsOrThrow("prompt")
+                        .getFieldType()
+                        .getStructDefId()
+                        .getName())
+                .isEqualTo(PROMPT_STRUCT_DEF_NAME);
         WfRun wfRun = null;
         WfSpecId wfSpecId = null;
 
@@ -77,7 +87,9 @@ class ExternalInlineStructPlaceholderTest {
 
             wfRun = blockingStub.runWf(RunWfRequest.newBuilder()
                     .setWfSpecName(WORKFLOW_NAME)
-                    .putVariables(REQUEST_VARIABLE, requestValue(requestStructDef.getId()))
+                    .putVariables(
+                            REQUEST_VARIABLE,
+                            requestValue(requestStructDef.getId(), promptStructDef.getId()))
                     .build());
             assertWorkflowCompleted(wfRun);
         } finally {
@@ -131,17 +143,28 @@ class ExternalInlineStructPlaceholderTest {
                         .doesNotContain(WORKFLOW_NAME));
     }
 
-    private static VariableValue requestValue(StructDefId structDefId) {
+    private static VariableValue requestValue(
+            StructDefId requestStructDefId, StructDefId promptStructDefId) {
+        VariableValue promptValue = VariableValue.newBuilder()
+                .setStruct(structValue(
+                        promptStructDefId,
+                        "text",
+                        VariableValue.newBuilder().setStr(PROMPT).build()))
+                .build();
+
         return VariableValue.newBuilder()
-                .setStruct(Struct.newBuilder()
-                        .setStructDefId(structDefId)
-                        .setStruct(InlineStruct.newBuilder()
-                                .putFields(
-                                        "prompt",
-                                        StructField.newBuilder()
-                                                .setValue(VariableValue.newBuilder()
-                                                        .setStr(PROMPT))
-                                                .build())))
+                .setStruct(structValue(requestStructDefId, "prompt", promptValue))
+                .build();
+    }
+
+    private static Struct structValue(
+            StructDefId structDefId, String fieldName, VariableValue fieldValue) {
+        return Struct.newBuilder()
+                .setStructDefId(structDefId)
+                .setStruct(InlineStruct.newBuilder()
+                        .putFields(
+                                fieldName,
+                                StructField.newBuilder().setValue(fieldValue).build()))
                 .build();
     }
 

--- a/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/ExternalInlineStructPlaceholderTest.java
+++ b/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/ExternalInlineStructPlaceholderTest.java
@@ -1,0 +1,155 @@
+package io.littlehorse.test;
+
+import static io.littlehorse.tasks.ExternalInlineStructTask.REQUEST_STRUCT_DEF_NAME;
+import static io.littlehorse.tasks.ExternalInlineStructTask.REQUEST_VARIABLE;
+import static io.littlehorse.tasks.ExternalInlineStructTask.RESPONSE_STRUCT_DEF_NAME;
+import static io.littlehorse.tasks.ExternalInlineStructTask.TASK_DEF_NAME;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.with;
+
+import io.littlehorse.common.ContainersTestResource;
+import io.littlehorse.common.InjectLittleHorseBlockingStub;
+import io.littlehorse.common.InjectLittleHorseConfig;
+import io.littlehorse.sdk.common.config.LHConfig;
+import io.littlehorse.sdk.common.proto.DeleteWfRunRequest;
+import io.littlehorse.sdk.common.proto.DeleteWfSpecRequest;
+import io.littlehorse.sdk.common.proto.GetLatestWfSpecRequest;
+import io.littlehorse.sdk.common.proto.InlineStruct;
+import io.littlehorse.sdk.common.proto.LHStatus;
+import io.littlehorse.sdk.common.proto.ListVariablesRequest;
+import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.RunWfRequest;
+import io.littlehorse.sdk.common.proto.SearchWfSpecRequest;
+import io.littlehorse.sdk.common.proto.Struct;
+import io.littlehorse.sdk.common.proto.StructDef;
+import io.littlehorse.sdk.common.proto.StructDefId;
+import io.littlehorse.sdk.common.proto.StructField;
+import io.littlehorse.sdk.common.proto.Variable;
+import io.littlehorse.sdk.common.proto.VariableValue;
+import io.littlehorse.sdk.common.proto.WfRun;
+import io.littlehorse.sdk.common.proto.WfSpecId;
+import io.littlehorse.sdk.wfsdk.WfRunVariable;
+import io.littlehorse.sdk.wfsdk.Workflow;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+@QuarkusIntegrationTest
+@QuarkusTestResource(ContainersTestResource.class)
+class ExternalInlineStructPlaceholderTest {
+
+    private static final String WORKFLOW_NAME = "external-inline-struct-test-workflow";
+    private static final String RESPONSE_VARIABLE = "response";
+    private static final String PROMPT = "Tell me about workflows";
+
+    @InjectLittleHorseBlockingStub
+    LittleHorseBlockingStub blockingStub;
+
+    @InjectLittleHorseConfig
+    LHConfig config;
+
+    @Test
+    void shouldRunQuarkusManagedTaskWithExternalConfiguredStructDefs() {
+        StructDef requestStructDef = blockingStub.getStructDef(
+                StructDefId.newBuilder().setName(REQUEST_STRUCT_DEF_NAME).build());
+        WfRun wfRun = null;
+        WfSpecId wfSpecId = null;
+
+        try {
+            Workflow workflow = Workflow.newWorkflow(WORKFLOW_NAME, wf -> {
+                WfRunVariable request = wf.declareStruct(REQUEST_VARIABLE, REQUEST_STRUCT_DEF_NAME)
+                        .required();
+                WfRunVariable response =
+                        wf.declareStruct(RESPONSE_VARIABLE, RESPONSE_STRUCT_DEF_NAME);
+                response.assign(wf.execute(TASK_DEF_NAME, request));
+            });
+            workflow.registerWfSpec(config);
+            wfSpecId = blockingStub
+                    .getLatestWfSpec(GetLatestWfSpecRequest.newBuilder()
+                            .setName(WORKFLOW_NAME)
+                            .build())
+                    .getId();
+
+            wfRun = blockingStub.runWf(RunWfRequest.newBuilder()
+                    .setWfSpecName(WORKFLOW_NAME)
+                    .putVariables(REQUEST_VARIABLE, requestValue(requestStructDef.getId()))
+                    .build());
+            assertWorkflowCompleted(wfRun);
+        } finally {
+            if (wfRun != null) {
+                blockingStub.deleteWfRun(
+                        DeleteWfRunRequest.newBuilder().setId(wfRun.getId()).build());
+            }
+            if (wfSpecId != null) {
+                blockingStub.deleteWfSpec(
+                        DeleteWfSpecRequest.newBuilder().setId(wfSpecId).build());
+            }
+        }
+
+        assertWorkflowRemoved();
+    }
+
+    private void assertWorkflowCompleted(WfRun wfRun) {
+        with().pollInterval(Duration.ofSeconds(1))
+                .ignoreExceptions()
+                .await()
+                .atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> {
+                    assertThat(blockingStub.getWfRun(wfRun.getId()).getStatus())
+                            .isEqualTo(LHStatus.COMPLETED);
+
+                    VariableValue response = getVariableValue(blockingStub
+                            .listVariables(ListVariablesRequest.newBuilder()
+                                    .setWfRunId(wfRun.getId())
+                                    .build())
+                            .getResultsList());
+                    assertThat(response.getStruct().getStructDefId().getName())
+                            .isEqualTo(RESPONSE_STRUCT_DEF_NAME);
+                    assertThat(response.getStruct()
+                                    .getStruct()
+                                    .getFieldsOrThrow("response")
+                                    .getValue()
+                                    .getStr())
+                            .isEqualTo(PROMPT);
+                });
+    }
+
+    private void assertWorkflowRemoved() {
+        with().pollInterval(Duration.ofSeconds(1))
+                .ignoreExceptions()
+                .await()
+                .atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> assertThat(blockingStub
+                                .searchWfSpec(SearchWfSpecRequest.newBuilder().build())
+                                .getResultsList())
+                        .extracting(WfSpecId::getName)
+                        .doesNotContain(WORKFLOW_NAME));
+    }
+
+    private static VariableValue requestValue(StructDefId structDefId) {
+        return VariableValue.newBuilder()
+                .setStruct(Struct.newBuilder()
+                        .setStructDefId(structDefId)
+                        .setStruct(InlineStruct.newBuilder()
+                                .putFields(
+                                        "prompt",
+                                        StructField.newBuilder()
+                                                .setValue(VariableValue.newBuilder()
+                                                        .setStr(PROMPT))
+                                                .build())))
+                .build();
+    }
+
+    private static VariableValue getVariableValue(List<Variable> variables) {
+        return variables.stream()
+                .filter(variable -> variable.getId().getName().equals(RESPONSE_VARIABLE))
+                .map(Variable::getValue)
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/StructRegistrationTest.java
+++ b/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/StructRegistrationTest.java
@@ -39,6 +39,9 @@ class StructRegistrationTest {
                                     .setName("lh-address")
                                     .build())
                             .addResults(StructDefId.newBuilder()
+                                    .setName("lh-external-prompt")
+                                    .build())
+                            .addResults(StructDefId.newBuilder()
                                     .setName("lh-external-request")
                                     .build())
                             .addResults(StructDefId.newBuilder()
@@ -52,7 +55,7 @@ class StructRegistrationTest {
                                     .build())
                             .build();
 
-                    assertThat(results.getResultsCount()).isEqualTo(5);
+                    assertThat(results.getResultsCount()).isEqualTo(6);
                     assertThat(results).isEqualTo(expectedResult);
                 });
     }

--- a/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/StructRegistrationTest.java
+++ b/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/StructRegistrationTest.java
@@ -39,6 +39,12 @@ class StructRegistrationTest {
                                     .setName("lh-address")
                                     .build())
                             .addResults(StructDefId.newBuilder()
+                                    .setName("lh-external-request")
+                                    .build())
+                            .addResults(StructDefId.newBuilder()
+                                    .setName("lh-external-response")
+                                    .build())
+                            .addResults(StructDefId.newBuilder()
                                     .setName("lh-inline-customer")
                                     .build())
                             .addResults(StructDefId.newBuilder()
@@ -46,7 +52,7 @@ class StructRegistrationTest {
                                     .build())
                             .build();
 
-                    assertThat(results.getResultsCount()).isEqualTo(3);
+                    assertThat(results.getResultsCount()).isEqualTo(5);
                     assertThat(results).isEqualTo(expectedResult);
                 });
     }

--- a/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/TaskRegistrationTest.java
+++ b/integration-tests/littlehorse-quarkus/src/integrationTest/java/io/littlehorse/test/TaskRegistrationTest.java
@@ -49,6 +49,9 @@ class TaskRegistrationTest {
                             .addResults(TaskDefId.newBuilder()
                                     .setName("email-inline-customer")
                                     .build())
+                            .addResults(TaskDefId.newBuilder()
+                                    .setName("external-inline-struct-test-task")
+                                    .build())
                             .addResults(
                                     TaskDefId.newBuilder().setName("get-uuid").build())
                             .addResults(
@@ -67,7 +70,7 @@ class TaskRegistrationTest {
                                     TaskDefId.newBuilder().setName("sum-array").build())
                             .build();
 
-                    assertThat(results.getResultsCount()).isEqualTo(13);
+                    assertThat(results.getResultsCount()).isEqualTo(14);
                     assertThat(results).isEqualTo(expectedResult);
                 });
     }

--- a/integration-tests/littlehorse-quarkus/src/main/java/io/littlehorse/tasks/ExternalInlineStructTask.java
+++ b/integration-tests/littlehorse-quarkus/src/main/java/io/littlehorse/tasks/ExternalInlineStructTask.java
@@ -1,0 +1,31 @@
+package io.littlehorse.tasks;
+
+import io.littlehorse.quarkus.task.LHTask;
+import io.littlehorse.sdk.common.proto.InlineStruct;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+import io.littlehorse.sdk.worker.LHType;
+
+@LHTask
+public class ExternalInlineStructTask {
+
+    public static final String TASK_DEF_NAME = "external-inline-struct-test-task";
+    public static final String REQUEST_STRUCT_DEF_NAME = "lh-external-request";
+    public static final String RESPONSE_STRUCT_DEF_NAME = "lh-external-response";
+    public static final String REQUEST_VARIABLE = "request";
+
+    private static final String TASK_NAME_EXPRESSION = "${external.inline-struct.task.name}";
+    private static final String REQUEST_STRUCT_EXPRESSION =
+            "${external.inline-struct.request.name}";
+    private static final String RESPONSE_STRUCT_EXPRESSION =
+            "${external.inline-struct.response.name}";
+
+    @LHTaskMethod(TASK_NAME_EXPRESSION)
+    @LHType(structDefName = RESPONSE_STRUCT_EXPRESSION)
+    public InlineStruct transform(
+            @LHType(name = REQUEST_VARIABLE, structDefName = REQUEST_STRUCT_EXPRESSION)
+                    InlineStruct request) {
+        return InlineStruct.newBuilder()
+                .putFields("response", request.getFieldsOrThrow("prompt"))
+                .build();
+    }
+}

--- a/integration-tests/littlehorse-quarkus/src/main/java/io/littlehorse/tasks/ExternalInlineStructTask.java
+++ b/integration-tests/littlehorse-quarkus/src/main/java/io/littlehorse/tasks/ExternalInlineStructTask.java
@@ -9,6 +9,7 @@ import io.littlehorse.sdk.worker.LHType;
 public class ExternalInlineStructTask {
 
     public static final String TASK_DEF_NAME = "external-inline-struct-test-task";
+    public static final String PROMPT_STRUCT_DEF_NAME = "lh-external-prompt";
     public static final String REQUEST_STRUCT_DEF_NAME = "lh-external-request";
     public static final String RESPONSE_STRUCT_DEF_NAME = "lh-external-response";
     public static final String REQUEST_VARIABLE = "request";
@@ -25,7 +26,13 @@ public class ExternalInlineStructTask {
             @LHType(name = REQUEST_VARIABLE, structDefName = REQUEST_STRUCT_EXPRESSION)
                     InlineStruct request) {
         return InlineStruct.newBuilder()
-                .putFields("response", request.getFieldsOrThrow("prompt"))
+                .putFields(
+                        "response",
+                        request.getFieldsOrThrow("prompt")
+                                .getValue()
+                                .getStruct()
+                                .getStruct()
+                                .getFieldsOrThrow("text"))
                 .build();
     }
 }

--- a/integration-tests/littlehorse-quarkus/src/main/resources/application.properties
+++ b/integration-tests/littlehorse-quarkus/src/main/resources/application.properties
@@ -5,3 +5,6 @@ retry.multiplier=2.2
 struct.person.name=lh-person
 struct.address.name=lh-address
 struct.inline-customer.name=lh-inline-customer
+external.inline-struct.task.name=external-inline-struct-test-task
+external.inline-struct.request.name=lh-external-request
+external.inline-struct.response.name=lh-external-response

--- a/integration-tests/littlehorse-saddle-bag/src/integrationTest/java/io/littlehorse/common/SaddleBagManifest.java
+++ b/integration-tests/littlehorse-saddle-bag/src/integrationTest/java/io/littlehorse/common/SaddleBagManifest.java
@@ -7,8 +7,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Reads the saddle bag manifest generated at build time by the saddle bag extension.
@@ -38,10 +36,6 @@ public final class SaddleBagManifest {
         return manifest.path("tasks").path(name);
     }
 
-    public static JsonNode struct(JsonNode manifest, String name) {
-        return manifest.path("structs").path(name);
-    }
-
     /**
      * Finds an element inside a manifest array (e.g. {@code configs} or {@code inputs}) whose
      * {@code fieldName} equals {@code value}. Returns a missing node when not found.
@@ -55,14 +49,5 @@ public final class SaddleBagManifest {
             }
         }
         return MAPPER.missingNode();
-    }
-
-    /** Collects every element of a JSON array as plain text values. */
-    public static List<String> texts(JsonNode array) {
-        List<String> values = new ArrayList<>();
-        if (array != null && array.isArray()) {
-            array.forEach(element -> values.add(element.asText()));
-        }
-        return values;
     }
 }

--- a/integration-tests/littlehorse-saddle-bag/src/integrationTest/java/io/littlehorse/test/SaddleBagManifestTest.java
+++ b/integration-tests/littlehorse-saddle-bag/src/integrationTest/java/io/littlehorse/test/SaddleBagManifestTest.java
@@ -11,6 +11,9 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @QuarkusIntegrationTest
 @QuarkusTestResource(ContainersTestResource.class)
 class SaddleBagManifestTest {
@@ -34,6 +37,14 @@ class SaddleBagManifestTest {
         assertThat(metadata.path("licence").asText()).isEqualTo("Apache-2.0");
         assertThat(metadata.path("docker-image").asText())
                 .isEqualTo("ghcr.io/littlehorse/integration-tests-saddle-bag");
-        assertThat(SaddleBagManifest.texts(metadata.path("tags"))).contains("test", "integration");
+        assertThat(texts(metadata.path("tags"))).contains("test", "integration");
+    }
+
+    private static List<String> texts(JsonNode array) {
+        List<String> values = new ArrayList<>();
+        if (array != null && array.isArray()) {
+            array.forEach(element -> values.add(element.asText()));
+        }
+        return values;
     }
 }

--- a/integration-tests/littlehorse-saddle-bag/src/integrationTest/java/io/littlehorse/test/SaddleBagStructMetadataTest.java
+++ b/integration-tests/littlehorse-saddle-bag/src/integrationTest/java/io/littlehorse/test/SaddleBagStructMetadataTest.java
@@ -17,7 +17,7 @@ class SaddleBagStructMetadataTest {
 
     @Test
     void shouldEmitStructWithPropertyTypes() {
-        JsonNode struct = SaddleBagManifest.struct(SaddleBagManifest.read(), "address");
+        JsonNode struct = SaddleBagManifest.read().path("structs").path("address");
         assertThat(struct.isMissingNode()).isFalse();
 
         JsonNode properties = struct.path("properties");


### PR DESCRIPTION
Collect parameter and return-type StructDef expressions at build time and resolve them from Quarkus configuration.

Add unit and integration coverage for externally registered InlineStruct definitions.

Assisted-by: Codex GPT-5