### PR TITLE
chore(ci): Update changelog genration config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Format
         uses: ./.github/actions/format
 
@@ -46,7 +46,7 @@ jobs:
         java-version: ["17", "21", "25"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Unit Tests
         uses: ./.github/actions/unit-tests
         with:
@@ -66,7 +66,7 @@ jobs:
           - littlehorse-saddle-bag
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Integration Tests
         uses: ./.github/actions/integration-tests
         with:
@@ -80,7 +80,7 @@ jobs:
       - integration-tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Publish
         uses: ./.github/actions/publish
         with:
@@ -98,15 +98,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          fetch-tags: true
       - name: Generate a Changelog
         uses: orhun/git-cliff-action@v4
         id: git-cliff
         with:
+          version: "2.13.1"
           config: cliff.toml
-          args: --verbose --current
+          args: --verbose --latest --use-branch-tags
         env:
           OUTPUT: CHANGELOG.md
       - name: Create Release
@@ -125,7 +127,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Docker Build RESTful Gateway
         uses: ./.github/actions/docker-build
         with:


### PR DESCRIPTION
Upgrades gitcliff configurations to support `actions/checkout` v7